### PR TITLE
HOCS-2692: Create Multiple Correspondents

### DIFF
--- a/src/main/java/uk/gov/digital/ho/hocs/client/casework/dto/ComplaintCorrespondent.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/client/casework/dto/ComplaintCorrespondent.java
@@ -5,6 +5,7 @@ import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Setter;
 import org.springframework.lang.NonNull;
+import uk.gov.digital.ho.hocs.queue.common.CorrespondentType;
 
 import javax.validation.constraints.NotEmpty;
 
@@ -16,7 +17,7 @@ public class ComplaintCorrespondent {
 
     @NonNull
     @JsonProperty(value = "type", required = true)
-    String type;
+    CorrespondentType type;
 
     @NonNull
     @NotEmpty
@@ -29,9 +30,9 @@ public class ComplaintCorrespondent {
     @JsonProperty("email")
     String email;
 
-    public ComplaintCorrespondent(@NonNull @NotEmpty String fullname) {
+    public ComplaintCorrespondent(@NonNull @NotEmpty String fullname, @NonNull @NotEmpty CorrespondentType type) {
         this.fullname = fullname;
-        this.type = "COMPLAINT";
+        this.type = type;
     }
 
 }

--- a/src/main/java/uk/gov/digital/ho/hocs/queue/common/ComplaintData.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/queue/common/ComplaintData.java
@@ -3,6 +3,8 @@ package uk.gov.digital.ho.hocs.queue.common;
 import uk.gov.digital.ho.hocs.client.casework.dto.ComplaintCorrespondent;
 
 import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
 
 public interface ComplaintData {
 
@@ -10,7 +12,7 @@ public interface ComplaintData {
 
     String getComplaintType();
 
-    ComplaintCorrespondent getComplaintCorrespondent();
+    List<ComplaintCorrespondent> getComplaintCorrespondent();
 
     String getFormattedDocument();
 

--- a/src/main/java/uk/gov/digital/ho/hocs/queue/common/CorrespondentType.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/queue/common/CorrespondentType.java
@@ -1,0 +1,6 @@
+package uk.gov.digital.ho.hocs.queue.common;
+
+public enum CorrespondentType {
+    COMPLAINANT,
+    THIRD_PARTY_REP,
+}

--- a/src/test/java/uk/gov/digital/ho/hocs/client/casework/CaseworkClientTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/client/casework/CaseworkClientTest.java
@@ -10,6 +10,7 @@ import org.springframework.http.ResponseEntity;
 import uk.gov.digital.ho.hocs.application.RestClient;
 import uk.gov.digital.ho.hocs.client.casework.dto.ComplaintCorrespondent;
 import uk.gov.digital.ho.hocs.client.casework.dto.UpdateStageUserRequest;
+import uk.gov.digital.ho.hocs.queue.common.CorrespondentType;
 
 import java.util.UUID;
 
@@ -99,7 +100,7 @@ public class CaseworkClientTest {
         UUID caseUUID = UUID.randomUUID();
         UUID stageForCaseUUID = UUID.randomUUID();
 
-        ComplaintCorrespondent ComplaintCorrespondent = new ComplaintCorrespondent("Baz Smith");
+        ComplaintCorrespondent ComplaintCorrespondent = new ComplaintCorrespondent("Baz Smith", CorrespondentType.COMPLAINANT);
 
         caseworkClient.addCorrespondentToCase(caseUUID, stageForCaseUUID, ComplaintCorrespondent);
 

--- a/src/test/java/uk/gov/digital/ho/hocs/queue/common/ComplaintServiceTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/queue/common/ComplaintServiceTest.java
@@ -85,7 +85,7 @@ public class ComplaintServiceTest {
 
         verify(caseworkClient).updateStageUser(caseUUID, stageForCaseUUID, UUID.fromString(user));
 
-        verify(caseworkClient).addCorrespondentToCase(eq(caseUUID), eq(stageForCaseUUID), any(ComplaintCorrespondent.class));
+        verify(caseworkClient, times(2)).addCorrespondentToCase(eq(caseUUID), eq(stageForCaseUUID), any(ComplaintCorrespondent.class));
 
         verify(workflowClient, times(2)).advanceCase(eq(caseUUID), eq(stageForCaseUUID), anyMap());
 

--- a/src/test/java/uk/gov/digital/ho/hocs/queue/ukvi/UKVIComplaintDataTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/queue/ukvi/UKVIComplaintDataTest.java
@@ -3,11 +3,15 @@ package uk.gov.digital.ho.hocs.queue.ukvi;
 import org.junit.Test;
 import uk.gov.digital.ho.hocs.client.casework.dto.ComplaintCorrespondent;
 import uk.gov.digital.ho.hocs.queue.common.ComplaintData;
+import uk.gov.digital.ho.hocs.queue.common.CorrespondentType;
 import uk.gov.digital.ho.hocs.queue.ukvi.UKVIComplaintData;
 
 import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 import static uk.gov.digital.ho.hocs.testutil.TestFileReader.getResourceFileAsString;
 
 public class UKVIComplaintDataTest {
@@ -27,8 +31,11 @@ public class UKVIComplaintDataTest {
     @Test
     public void shouldGetUkviComplaintApplicantCorrespondent() {
         ComplaintData complaintData = new UKVIComplaintData(getResourceFileAsString("applicantCorrespondent.json"));
-        ComplaintCorrespondent ukviComplaintApplicantCorrespondent = complaintData.getComplaintCorrespondent();
-        assertEquals("COMPLAINT", ukviComplaintApplicantCorrespondent.getType());
+        List<ComplaintCorrespondent> correspondents = complaintData.getComplaintCorrespondent();
+        assertTrue(correspondents.size() == 1);
+
+        ComplaintCorrespondent ukviComplaintApplicantCorrespondent = correspondents.get(0);
+        assertEquals(CorrespondentType.COMPLAINANT, ukviComplaintApplicantCorrespondent.getType());
         assertEquals("occaecat Lorem", ukviComplaintApplicantCorrespondent.getFullname());
         assertEquals("sss@uevptde.com", ukviComplaintApplicantCorrespondent.getEmail());
         assertEquals("0114 4960002", ukviComplaintApplicantCorrespondent.getTelephone());
@@ -37,16 +44,34 @@ public class UKVIComplaintDataTest {
     @Test
     public void shouldGetPartialUkviComplaintApplicantCorrespondent() {
         ComplaintData complaintData = new UKVIComplaintData(getResourceFileAsString("applicantCorrespondentPartial.json"));
-        ComplaintCorrespondent ukviComplaintApplicantCorrespondent = complaintData.getComplaintCorrespondent();
-        assertEquals("COMPLAINT", ukviComplaintApplicantCorrespondent.getType());
+        List<ComplaintCorrespondent> correspondents = complaintData.getComplaintCorrespondent();
+        assertTrue(correspondents.size() == 1);
+
+        ComplaintCorrespondent ukviComplaintApplicantCorrespondent = correspondents.get(0);
+        assertEquals(CorrespondentType.COMPLAINANT, ukviComplaintApplicantCorrespondent.getType());
         assertEquals("occaecat Lorem", ukviComplaintApplicantCorrespondent.getFullname());
     }
 
     @Test
     public void shouldGetUkviComplaintAgentCorrespondent() {
         ComplaintData complaintData = new UKVIComplaintData(getResourceFileAsString("agentCorrespondent.json"));
-        ComplaintCorrespondent ukviComplaintApplicantCorrespondent = complaintData.getComplaintCorrespondent();
-        assertEquals("COMPLAINT", ukviComplaintApplicantCorrespondent.getType());
-        assertEquals("tempor", ukviComplaintApplicantCorrespondent.getFullname());
+        List<ComplaintCorrespondent> correspondents = complaintData.getComplaintCorrespondent();
+        assertTrue(correspondents.size() == 2);
+
+        ComplaintCorrespondent applicantCorrespondent = correspondents.get(0);
+        assertEquals(CorrespondentType.COMPLAINANT, applicantCorrespondent.getType());
+        assertEquals("tempor", applicantCorrespondent.getFullname());
+
+        ComplaintCorrespondent agentCorrespondent = correspondents.get(1);
+        assertEquals(CorrespondentType.THIRD_PARTY_REP, agentCorrespondent.getType());
+        assertEquals("sint mollit est", agentCorrespondent.getFullname());
+        assertEquals("64E@fmZgjGfpG.cfb", agentCorrespondent.getEmail());
+    }
+
+    @Test
+    public void shouldGetUkviComplaintExistingNoCorrespondent() {
+        ComplaintData complaintData = new UKVIComplaintData(getResourceFileAsString("existingNoCorrespondent.json"));
+        List<ComplaintCorrespondent> correspondents = complaintData.getComplaintCorrespondent();
+        assertTrue(correspondents.size() == 0);
     }
 }

--- a/src/test/java/uk/gov/digital/ho/hocs/queue/ukvi/UKVIComplaintServiceTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/queue/ukvi/UKVIComplaintServiceTest.java
@@ -33,4 +33,15 @@ public class UKVIComplaintServiceTest {
         verify(complaintService).createComplaint(any(UKVIComplaintData.class), eq(complaintTypeData));
     }
 
+    @Test
+    public void shouldCreateComplaintWithNoCorrespondent() throws IOException {
+        UKVITypeData complaintTypeData = new UKVITypeData();
+        UKVIComplaintService ukviComplaintService = new UKVIComplaintService(complaintService, clientContext, complaintTypeData, "user", "group");
+        String json = getResourceFileAsString("existingNoCorrespondent.json");
+
+        ukviComplaintService.createComplaint(json, "messageId");
+
+        verify(complaintService).createComplaint(any(UKVIComplaintData.class), eq(complaintTypeData));
+    }
+
 }

--- a/src/test/resources/existingNoCorrespondent.json
+++ b/src/test/resources/existingNoCorrespondent.json
@@ -1,0 +1,12 @@
+{
+  "creationDate": "1948-08-23",
+  "complaint": {
+    "complaintType": "EXISTING",
+    "complaintDetails": {
+      "complaintText": "occaecat proident labore dolor sunt",
+      "previousComplaint": {
+        "complaintReferenceNumber": "id"
+      }
+    }
+  }
+}


### PR DESCRIPTION
**What:**
- Enables multiple correspondents to be created during case creation.
- Ensures the 'Complainant' is set as the Primary Correspondent, when provided.
- Allows case to be created with no correspondents, passed as part of the complaint.

**Why:**
- Complaints submitted by a third-party representative need to have the 'Agent' and the 'Complainant' added to the case correspondents with the Complainant always being the 'Primary'.
- Complaints about an existing complaint can be submitted without any correspondent details, so need to be able to create a case without any correspondents.