### PR TITLE
HOCS-3240 - Add maxMessagesPerPoll as a property

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ The following table contains the mandatory and optional properties that need to 
 | CASE_CREATOR_UKVI_COMPLAINT_QUEUE_BACKOFF_MULTIPLIER | Enables exponential backoff and sets the multiplier used to increase the delay between redeliveries | 5 | No |
 | CASE_CREATOR_UKVI_COMPLAINT_QUEUE_BACKOFF_IDLE_THRESHOLD | The number of subsequent idle polls that should happen before the backoffMultipler should kick-in. | 1 | No |
 | CASE_CREATOR_UKVI_COMPLAINT_QUEUE_WAIT_TIME_SECONDS | The duration (in seconds) for which the call waits for a message to arrive in the queue before returning. | 20 | No |
+| CASE_CREATOR_UKVI_COMPLAINT_QUEUE_MAX_MESSAGES_PER_POLL | The maximum number of messages at each polling | 1 | No |
 | CASE_CREATOR_UKVI_COMPLAINT_QUEUE_INITIAL_DELAY | Milliseconds before the first poll starts. | 5000 | No |
 | CASE_CREATOR_UKVI_COMPLAINT_QUEUE_POLL_DELAY | Milliseconds before the next poll. | 100 | No |
 | CASE_CREATOR_REST_CLIENT_RETRIES |The maximum number of retry attempts | 10 | No |

--- a/src/main/java/uk/gov/digital/ho/hocs/config/AppCustomProperties.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/config/AppCustomProperties.java
@@ -68,6 +68,8 @@ public class AppCustomProperties {
         @NotBlank
         private Integer queueInitialDelay;
         @NotBlank
+        private Integer maxMessagesPerPoll;
+        @NotBlank
         private String redrivePolicy;
         @NotBlank
         private String queueProperties;

--- a/src/main/java/uk/gov/digital/ho/hocs/queue/ukvi/UKVIComplaintQueueBuilder.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/queue/ukvi/UKVIComplaintQueueBuilder.java
@@ -24,6 +24,7 @@ public class UKVIComplaintQueueBuilder {
     private final int backOffMultiplier;
     private final int backoffIdleThreshold;
     private final int waitTimeSeconds;
+    private final int maxMessagesPerPoll;
     private final int initialDelay;
     private final int pollDelay;
 
@@ -38,6 +39,7 @@ public class UKVIComplaintQueueBuilder {
                                      @Value("${case.creator.ukvi-complaint.queue-backoff-idle-threshold}") int backoffIdleThreshold,
                                      @Value("${case.creator.ukvi-complaint.queue-backOff-multiplier}") int backOffMultiplier,
                                      @Value("${case.creator.ukvi-complaint.queue-wait-time-seconds}") int waitTimeSeconds,
+                                     @Value("${case.creator.ukvi-complaint.queue-max-messages-per-poll}") int maxMessagesPerPoll, 
                                      @Value("${case.creator.ukvi-complaint.queue-initial-delay}") int initialDelay,
                                      @Value("${case.creator.ukvi-complaint.queue-poll-delay}") int pollDelay) {
         this.sqsQueuePrefix = sqsQueuePrefix;
@@ -50,6 +52,7 @@ public class UKVIComplaintQueueBuilder {
         this.backoffIdleThreshold = backoffIdleThreshold;
         this.backOffMultiplier = backOffMultiplier;
         this.waitTimeSeconds = waitTimeSeconds;
+        this.maxMessagesPerPoll = maxMessagesPerPoll;
         this.initialDelay = initialDelay;
         this.pollDelay = pollDelay;
 
@@ -69,9 +72,17 @@ public class UKVIComplaintQueueBuilder {
                 "&waitTimeSeconds=%s" +
                 "&backoffIdleThreshold=%s" +
                 "&backoffMultiplier=%s" +
+                "&maxMessagesPerPoll=%s" +
                 "&initialDelay=%s" +
                 "&delay=%s";
-        String queueProperties = String.format(queuePropertiesTemplate, redrivePolicy, waitTimeSeconds, backoffIdleThreshold, backOffMultiplier, initialDelay, pollDelay);
+        String queueProperties = String.format(queuePropertiesTemplate, 
+                redrivePolicy, 
+                waitTimeSeconds, 
+                backoffIdleThreshold, 
+                backOffMultiplier, 
+                maxMessagesPerPoll, 
+                initialDelay, 
+                pollDelay);
 
         return sqsQueuePrefix.getPrefix() + queueName + queueProperties;
     }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -26,8 +26,9 @@ case.creator.ukvi-complaint.queue-redelivery-delay=10000
 case.creator.ukvi-complaint.queue-backOff-multiplier=5
 case.creator.ukvi-complaint.queue-backoff-idle-threshold=1
 case.creator.ukvi-complaint.queue-wait-time-seconds=20
+case.creator.ukvi-complaint.queue-max-messages-per-poll=1
 case.creator.ukvi-complaint.queue-initial-delay=5000
-case.creator.ukvi-complaint.queue-poll-delay=100
+case.creator.ukvi-complaint.queue-poll-delay=10000
 
 audit.namespace=local
 audit.app-name=${info.app.name}

--- a/src/test/java/uk/gov/digital/ho/hocs/queue/ukvi/UKVIComplaintQueueBuilderTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/queue/ukvi/UKVIComplaintQueueBuilderTest.java
@@ -17,6 +17,7 @@ public class UKVIComplaintQueueBuilderTest {
     int backoffIdleThreshold = 3;
     int backOffMultiplier = 4;
     int waitTimeSeconds = 5;
+    int maxMessagesPerPoll = 1;
     int initialDelay = 6;
     int pollDelay = 7;
 
@@ -36,6 +37,7 @@ public class UKVIComplaintQueueBuilderTest {
                 backoffIdleThreshold,
                 backOffMultiplier,
                 waitTimeSeconds,
+                maxMessagesPerPoll, 
                 initialDelay,
                 pollDelay);
 
@@ -44,10 +46,11 @@ public class UKVIComplaintQueueBuilderTest {
                 "&waitTimeSeconds=%d" +
                 "&backoffIdleThreshold=%d" +
                 "&backoffMultiplier=%d" +
+                "&maxMessagesPerPoll=%d" +
                 "&initialDelay=%d" +
                 "&delay=%d",
                 queueName, maximumRedeliveries, region, accountId, dlQueueName, waitTimeSeconds,
-                backoffIdleThreshold, backOffMultiplier, initialDelay, pollDelay), queueBuilder.getQueue());
+                backoffIdleThreshold, backOffMultiplier, maxMessagesPerPoll, initialDelay, pollDelay), queueBuilder.getQueue());
     }
 
     @Test
@@ -66,6 +69,7 @@ public class UKVIComplaintQueueBuilderTest {
                 backoffIdleThreshold,
                 backOffMultiplier,
                 waitTimeSeconds,
+                maxMessagesPerPoll, 
                 initialDelay,
                 pollDelay);
 
@@ -74,10 +78,11 @@ public class UKVIComplaintQueueBuilderTest {
                 "&waitTimeSeconds=%d" +
                 "&backoffIdleThreshold=%d" +
                 "&backoffMultiplier=%d" +
+                "&maxMessagesPerPoll=%d" +
                 "&initialDelay=%d" +
                 "&delay=%d",
                 region, accountId, queueName, maximumRedeliveries, region, accountId, dlQueueName, waitTimeSeconds,
-                backoffIdleThreshold, backOffMultiplier, initialDelay, pollDelay
+                backoffIdleThreshold, backOffMultiplier, maxMessagesPerPoll, initialDelay, pollDelay
                 ), queueBuilder.getQueue());
     }
 


### PR DESCRIPTION
- Add maxMessagesPerPoll as a property so that we can limit the number of messages read per poll.
- Set the poll delay to 10 seconds.