### PR TITLE
HOCS-3646: Representative phone number added to relevant correspondent

### DIFF
--- a/src/main/java/uk/gov/digital/ho/hocs/queue/ukvi/UKVIComplaintData.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/queue/ukvi/UKVIComplaintData.java
@@ -27,6 +27,7 @@ public class UKVIComplaintData implements ComplaintData {
     public static final String AGENT_APPLICANT_NAME = "$.complaint.reporterDetails.applicantDetails.applicantName";
     public static final String AGENT_AGENT_NAME = "$.complaint.reporterDetails.agentDetails.agentName";
     public static final String AGENT_AGENT_EMAIL = "$.complaint.reporterDetails.agentDetails.agentEmail";
+    public static final String AGENT_AGENT_PHONE = "$.complaint.reporterDetails.agentDetails.agentPhone";
 
     private final ReadContext ctx;
     private final String jsonBody;
@@ -62,6 +63,7 @@ public class UKVIComplaintData implements ComplaintData {
                 ComplaintCorrespondent applicantCorrespondent = new ComplaintCorrespondent(ctx.read(AGENT_APPLICANT_NAME), CorrespondentType.COMPLAINANT);
                 ComplaintCorrespondent agentCorrespondent = new ComplaintCorrespondent(ctx.read(AGENT_AGENT_NAME), CorrespondentType.THIRD_PARTY_REP);
                 optionalString(ctx, AGENT_AGENT_EMAIL).ifPresent(agentCorrespondent::setEmail);
+                optionalString(ctx, AGENT_AGENT_PHONE).ifPresent(agentCorrespondent::setTelephone);
                 //First correspondent added becomes the primary correspondent for the case.
                 correspondents.add(applicantCorrespondent);
                 correspondents.add(agentCorrespondent);

--- a/src/test/java/uk/gov/digital/ho/hocs/queue/ukvi/UKVIComplaintDataTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/queue/ukvi/UKVIComplaintDataTest.java
@@ -66,6 +66,7 @@ public class UKVIComplaintDataTest {
         assertEquals(CorrespondentType.THIRD_PARTY_REP, agentCorrespondent.getType());
         assertEquals("sint mollit est", agentCorrespondent.getFullname());
         assertEquals("64E@fmZgjGfpG.cfb", agentCorrespondent.getEmail());
+        assertEquals("01234567890", agentCorrespondent.getTelephone());
     }
 
     @Test

--- a/src/test/resources/agentCorrespondent.json
+++ b/src/test/resources/agentCorrespondent.json
@@ -16,7 +16,8 @@
       "agentDetails": {
         "agentName": "sint mollit est",
         "agentType": "LEGAL_REP",
-        "agentEmail": "64E@fmZgjGfpG.cfb"
+        "agentEmail": "64E@fmZgjGfpG.cfb",
+        "agentPhone": "01234567890"
       }
     },
     "complaintDetails": {


### PR DESCRIPTION
Fixes an issue where the phone number of a third party representative wasn't being added to the correspondent.