### PR TITLE
Fix deployment configuration

### DIFF
--- a/kube/kd/deployment.yaml
+++ b/kube/kd/deployment.yaml
@@ -155,8 +155,6 @@ spec:
                 - SETGID
           envFrom:
             - configMapRef:
-                name: hocs-queue-config
-            - configMapRef:
                 name: hocs-complaint-identity
           env:
             - name: JAVA_OPTS
@@ -203,6 +201,11 @@ spec:
                 secretKeyRef:
                   name: {{.KUBE_NAMESPACE}}-audit-sqs
                   key: secret_access_key
+            - name: AWS_SNS_AUDIT_ACCOUNT_ID
+              valueFrom:
+                configMapKeyRef:
+                  name: hocs-queue-config
+                  key: AWS_ACCOUNT_ID
             - name: AUDIT_SNS_TOPIC_NAME
               value:
                 '{{.KUBE_NAMESPACE}}-sns'

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -33,7 +33,7 @@ aws:
         secret-key:
         id:
       topic-name:
-      arn: arn:aws:sns:${aws.sns.config.region}:${aws.sns.audit.account}:${aws.sns.audit.topic-name}
+      arn: arn:aws:sns:${aws.sns.config.region}:${aws.sns.audit.account.id}:${aws.sns.audit.topic-name}
   s3:
     config:
       region: eu-west-2


### PR DESCRIPTION
At present the pods are in a backoff state as the configuration has not
been set correctly. This change amends the configuration to enable the
build to deploy successfully.