### PR TITLE
Specify port number

### DIFF
--- a/kube/kd/deployment.yaml
+++ b/kube/kd/deployment.yaml
@@ -161,6 +161,8 @@ spec:
               value: '-Xms768m -Xmx768m -Djavax.net.ssl.trustStore=/etc/keystore/truststore.jks -Dhttps.proxyHost=hocs-outbound-proxy.{{.KUBE_NAMESPACE}}.svc.cluster.local -Dhttps.proxyPort=31290 -Dhttp.nonProxyHosts=*.{{.KUBE_NAMESPACE}}.svc.cluster.local'
             - name: JDK_TRUST_FILE
               value: '/etc/keystore/truststore.jks'
+            - name: SERVER_PORT
+              value: '8080'
             - name: SPRING_PROFILES_ACTIVE
               value: 'sqs, sns, s3'
             - name: CASE_CREATOR_CASE_SERVICE

--- a/kube/kd/deployment.yaml
+++ b/kube/kd/deployment.yaml
@@ -155,8 +155,6 @@ spec:
                 - SETGID
           envFrom:
             - configMapRef:
-                name: hocs-queue-config
-            - configMapRef:
                 name: hocs-complaint-identity
           env:
             - name: JAVA_OPTS
@@ -203,6 +201,11 @@ spec:
                 secretKeyRef:
                   name: {{.KUBE_NAMESPACE}}-audit-sqs
                   key: secret_access_key
+            - name: AWS_SNS_AUDIT_ACCOUNT_ID
+              valueFrom:
+                configMapKeyRef:
+                  name: hocs-queue-config
+                  key: AWS_ACCOUNT_ID
             - name: AUDIT_SNS_TOPIC_NAME
               value:
                 '{{.KUBE_NAMESPACE}}-sns'

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -33,7 +33,7 @@ aws:
         secret-key:
         id:
       topic-name:
-      arn: arn:aws:sns:${aws.sns.config.region}:${aws.sns.audit.account}:${aws.sns.audit.topic-name}
+      arn: arn:aws:sns:${aws.sns.config.region}:${aws.sns.audit.account.id}:${aws.sns.audit.topic-name}
   s3:
     config:
       region: eu-west-2


### PR DESCRIPTION
We are currently not specifying the port number that the
spring application should start on. This means that the deployment
is attempting to hit 8080 but is getting connection refused as the
default is 8092.