### PR TITLE
Improve Dependabot Configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,5 @@ updates:
           interval: "daily"
       pull-request-branch-name:
         separator: "-"
+      reviewers:
+        - "UKHomeOffice/hocs-core"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,8 @@ updates:
       directory: "/"
       schedule:
           interval: "daily"
+      commit-message:
+          prefix: "⬆️ "    
       pull-request-branch-name:
         separator: "-"
       reviewers:


### PR DESCRIPTION
Add the `hocs-core` team as the reviewers for each of the dependabot PRs
to ensure we are properly informed about incoming changes.

Also incorporates a change to prefix all commits by `⬆️`. 