### PR TITLE
HOCS-4423: update case data with no correspondent

### DIFF
--- a/src/main/java/uk/gov/digital/ho/hocs/queue/common/ComplaintService.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/queue/common/ComplaintService.java
@@ -67,6 +67,9 @@ public class ComplaintService {
 
             caseworkClient.updateStageUser(caseUUID, stageForCaseUUID, UUID.fromString(clientContext.getUserId()));
 
+            Map<String, String> data = new HashMap<>();
+            data.put(COMPLAINT_TYPE_LABEL, complaintData.getComplaintType());
+
             List<ComplaintCorrespondent> correspondentsList = complaintData.getComplaintCorrespondent();
             if (!correspondentsList.isEmpty()) {
                 for (ComplaintCorrespondent correspondent : correspondentsList) {
@@ -74,23 +77,14 @@ public class ComplaintService {
                 }
 
                 UUID primaryCorrespondent = caseworkClient.getPrimaryCorrespondent(caseUUID);
-
+                data.put(CORRESPONDENTS_LABEL, primaryCorrespondent.toString());
                 log.info("createComplaint, added primary correspondent : caseUUID : {}, primaryCorrespondent : {}", caseUUID, primaryCorrespondent);
-
-                Map<String, String> correspondents = Collections.singletonMap(CORRESPONDENTS_LABEL, primaryCorrespondent.toString());
-
-                Map<String, String> complaintType = Collections.singletonMap(COMPLAINT_TYPE_LABEL, complaintData.getComplaintType());
-
-                HashMap<String, String> data = new HashMap<>();
-                data.putAll(correspondents);
-                data.putAll(complaintType);
-
-                caseworkClient.updateCase(caseUUID, stageForCaseUUID, data);
-
-                log.info("createComplaint, case data updated for correspondent and complaint type : caseUUID : {}, complaintType : {}", caseUUID, complaintType);
             } else {
                 log.info("createComplaint, no correspondents added to case : caseUUID : {}", caseUUID);
             }
+
+            caseworkClient.updateCase(caseUUID, stageForCaseUUID, data);
+            log.info("createComplaint, case data updated : caseUUID : {}, complaintType : {}", caseUUID, complaintData.getComplaintType());
 
             caseworkClient.updateStageTeam(caseUUID, stageForCaseUUID, UUID.fromString(clientContext.getTeamId()));
 

--- a/src/test/java/uk/gov/digital/ho/hocs/queue/common/ComplaintServiceTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/queue/common/ComplaintServiceTest.java
@@ -18,7 +18,9 @@ import uk.gov.digital.ho.hocs.queue.ukvi.UKVITypeData;
 
 import java.io.IOException;
 import java.time.LocalDate;
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
 import static org.mockito.ArgumentMatchers.any;
@@ -141,5 +143,18 @@ public class ComplaintServiceTest {
         goodSetup();
         when(caseworkClient.getPrimaryCorrespondent(caseUUID)).thenThrow(new NullPointerException());
         complaintService.createComplaint(new UKVIComplaintData(json), complaintTypeData);
+    }
+
+    @Test
+    public void createComplaintWithoutCorrespondentShouldSendType() {
+        Map<String, String> caseData  = Collections.singletonMap("ComplaintType", "EXISTING");
+
+        goodSetup();
+        when(workflowClient.createCase(any(CreateCaseRequest.class))).thenReturn(createCaseResponse);
+
+        var noCorrespondentJsonString = getResourceFileAsString("existingNoCorrespondent.json");
+        complaintService.createComplaint(new UKVIComplaintData(noCorrespondentJsonString), complaintTypeData);
+
+        verify(caseworkClient).updateCase(any(), any(), eq(caseData));
     }
 }


### PR DESCRIPTION
When a complaint comes through if there was no correspondent then the
case data was not updated with the complaint type. With all but 1 of the
complaint types correspondents are required. Complaints with
an `EXISTING` type don't have the correspondent requirement and
thus could lead to the case data not having the correct type. This
change ensures that the complaint type is always sent to the casework
service to be updated.