### PR TITLE
HOCS-4278: change sqs props to generic name

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,11 +50,11 @@ The following table contains the mandatory and optional properties that need to 
 | Property | Description | Example | Mandatory |
 | -------- | -------- |-------- |-------- |
 | AWS_SQS_CONFIG_REGION | The region for the AWS SQS queue | eu-west-2 | Yes |
-| AWS_SQS_UKVI_COMPLAINT_URL | The full AWS SQS queue URL | http://localhost:4566/queue/ukvi-complaint-queue | Yes |
-| AWS_SQS_UKVI_COMPLAINT_ACCOUNT_ACCESS_KEY | The SQS access key | 12345 | Yes
-| AWS_SQS_UKVI_COMPLAINT_ACCOUNT_SECRET_KEY | The SQS secret key | 12345 | Yes
-| AWS_SQS_UKVI_COMPLAINT_ATTRIBUTE_MAX_MESSAGES | The amount of messages to read at one time | 10 | No |
-| AWS_SQS_UKVI_COMPLAINT_ATTRIBUTE_WAIT_TIME | The poll time for the queue listener | 5 | No |
+| AWS_SQS_CASE_CREATOR_URL | The full AWS SQS queue URL | http://localhost:4566/queue/case-creator-queue | Yes |
+| AWS_SQS_CASE_CREATOR_ACCOUNT_ACCESS_KEY | The SQS access key | 12345 | Yes
+| AWS_SQS_CASE_CREATOR_ACCOUNT_SECRET_KEY | The SQS secret key | 12345 | Yes
+| AWS_SQS_CASE_CREATOR_ATTRIBUTE_MAX_MESSAGES | The amount of messages to read at one time | 10 | No |
+| AWS_SQS_CASE_CREATOR_ATTRIBUTE_WAIT_TIME | The poll time for the queue listener | 5 | No |
 | AWS_SNS_CONFIG_REGION | The region for the AWS SNS queue | eu-west-2 | Yes |
 | AWS_SNS_AUDIT_ACCOUNT_ACCESS_KEY | The SNS access key | 12345 | Yes
 | AWS_SNS_AUDIT_ACCOUNT_SECRET_KEY | The SNS secret key | 12345 | Yes

--- a/config/localstack/1-setup-sqs.sh
+++ b/config/localstack/1-setup-sqs.sh
@@ -11,5 +11,5 @@ until curl http://localstack:4566/health --silent | grep -q "running"; do
    echo "Waiting for LocalStack to be ready..."
 done
 
-aws sqs --endpoint-url=http://localstack:4566 create-queue --queue-name ukvi-complaint-queue-dlq
-aws sqs --endpoint-url=http://localstack:4566 create-queue --queue-name ukvi-complaint-queue --attributes '{"RedrivePolicy": "{\"deadLetterTargetArn\":\"arn:aws:sqs:eu-west-2:000000000000:ukvi-complaint-queue-dlq\",\"maxReceiveCount\":1}"}'
+aws sqs --endpoint-url=http://localstack:4566 create-queue --queue-name case-creator-queue-dlq
+aws sqs --endpoint-url=http://localstack:4566 create-queue --queue-name case-creator-queue --attributes '{"RedrivePolicy": "{\"deadLetterTargetArn\":\"arn:aws:sqs:eu-west-2:000000000000:case-creator-queue-dlq\",\"maxReceiveCount\":1}"}'

--- a/kube/kd/deployment.yaml
+++ b/kube/kd/deployment.yaml
@@ -174,17 +174,17 @@ spec:
                 secretKeyRef:
                   name: ui-casework-creds
                   key: plaintext
-            - name: AWS_SQS_UKVI_COMPLAINT_ACCOUNT_ACCESS_KEY
+            - name: AWS_SQS_CASE_CREATOR_ACCOUNT_ACCESS_KEY
               valueFrom:
                 secretKeyRef:
                   name: {{.KUBE_NAMESPACE}}-ukvi-complaint-sqs
                   key: access_key_id
-            - name: AWS_SQS_UKVI_COMPLAINT_ACCOUNT_SECRET_KEY
+            - name: AWS_SQS_CASE_CREATOR_ACCOUNT_SECRET_KEY
               valueFrom:
                 secretKeyRef:
                   name: {{.KUBE_NAMESPACE}}-ukvi-complaint-sqs
                   key: secret_access_key
-            - name: AWS_SQS_UKVI_COMPLAINT_URL
+            - name: AWS_SQS_CASE_CREATOR_URL
               valueFrom:
                 secretKeyRef:
                   name: {{.KUBE_NAMESPACE}}-ukvi-complaint-sqs

--- a/localDev/pushString.sh
+++ b/localDev/pushString.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env sh
 
-aws --endpoint-url=http://localhost:4561 sqs send-message --queue-url http://localhost:4576/queue/ukvi-complaint-queue --message-body "test" --delay-seconds 10 
+aws --endpoint-url=http://localhost:4566 sqs send-message --queue-url http://localhost:4566/queue/case-creator-queue --message-body "test" --delay-seconds 10

--- a/src/main/java/uk/gov/digital/ho/hocs/aws/SqsConfiguration.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/aws/SqsConfiguration.java
@@ -18,8 +18,8 @@ public class SqsConfiguration {
 
     @Primary
     @Bean
-    public AmazonSQSAsync sqsClient(@Value("${aws.sqs.ukvi-complaint.account.access-key}") String accessKey,
-                                    @Value("${aws.sqs.ukvi-complaint.account.secret-key}") String secretkey,
+    public AmazonSQSAsync sqsClient(@Value("${aws.sqs.case-creator.account.access-key}") String accessKey,
+                                    @Value("${aws.sqs.case-creator.account.secret-key}") String secretkey,
                                     @Value("${aws.sqs.config.region}") String region) {
         var credentialsProvider = new AWSStaticCredentialsProvider(
                 new BasicAWSCredentials(accessKey, secretkey));

--- a/src/main/java/uk/gov/digital/ho/hocs/aws/SqsMessageListenerContainerFactory.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/aws/SqsMessageListenerContainerFactory.java
@@ -15,7 +15,7 @@ public class SqsMessageListenerContainerFactory {
     @Bean
     @Profile("sqs")
     public SimpleMessageListenerContainerFactory awsMessageListenerContainerFactory(AmazonSQSAsync amazonSqs,
-                                                                                       @Value("${aws.sqs.ukvi-complaint.attributes.max-messages}") Integer maxMessages) {
+                                                                                       @Value("${aws.sqs.case-creator.attributes.max-messages}") Integer maxMessages) {
         return createMessageFactory(amazonSqs, maxMessages, null);
     }
 
@@ -23,8 +23,8 @@ public class SqsMessageListenerContainerFactory {
     @Bean
     @Profile("local")
     public SimpleMessageListenerContainerFactory localstackMessageListenerContainerFactory(AmazonSQSAsync amazonSqs,
-                                                                                           @Value("${aws.sqs.ukvi-complaint.attributes.max-messages}") Integer maxMessages,
-                                                                                           @Value("${aws.sqs.ukvi-complaint.attributes.wait-time}") Integer waitTime) {
+                                                                                           @Value("${aws.sqs.case-creator.attributes.max-messages}") Integer maxMessages,
+                                                                                           @Value("${aws.sqs.case-creator.attributes.wait-time}") Integer waitTime) {
         return createMessageFactory(amazonSqs, maxMessages, waitTime);
     }
 

--- a/src/main/java/uk/gov/digital/ho/hocs/queue/common/QueueListener.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/queue/common/QueueListener.java
@@ -20,7 +20,7 @@ public class QueueListener {
         this.queueMessageHandlers = queueMessageHandlers;
     }
 
-    @SqsListener(value = "${aws.sqs.ukvi-complaint.url}", deletionPolicy = SqsMessageDeletionPolicy.ON_SUCCESS)
+    @SqsListener(value = "${aws.sqs.case-creator.url}", deletionPolicy = SqsMessageDeletionPolicy.ON_SUCCESS)
     public void onComplaintEvent(String message, @Header("MessageId") String messageId) throws Exception {
         for (BaseMessageHandler messageHandler :
                 queueMessageHandlers) {

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -7,8 +7,8 @@ localstack:
 
 aws:
   sqs:
-    ukvi-complaint:
-      url: ${localstack.base-url}/queue/ukvi-complaint-queue
+    case-creator:
+      url: ${localstack.base-url}/queue/case-creator-queue
       account:
         access-key: 12345
         secret-key: 12345

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -17,7 +17,7 @@ aws:
   sqs:
     config:
       region: eu-west-2
-    ukvi-complaint:
+    case-creator:
       url:
       account:
         access-key:

--- a/src/test/java/uk/gov/digital/ho/hocs/clientutil/SQSSender.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/clientutil/SQSSender.java
@@ -18,7 +18,7 @@ public class SQSSender {
 
     public static void main(String[] args) {
         AmazonSQS sqs = sqsClient();
-        String QUEUE_NAME = "ukvi-complaint-queue";
+        String QUEUE_NAME = "case-creator-queue";
         String queueUrl = sqs.getQueueUrl(QUEUE_NAME).getQueueUrl();
         System.out.println(queueUrl);
 

--- a/src/test/java/uk/gov/digital/ho/hocs/queue/common/integration/AwsSqsIntegrationTestBase.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/queue/common/integration/AwsSqsIntegrationTestBase.java
@@ -18,7 +18,7 @@ public class AwsSqsIntegrationTestBase {
     @Autowired
     public AmazonSQSAsync amazonSQSAsync;
 
-    @Value("${aws.sqs.ukvi-complaint.url}")
+    @Value("${aws.sqs.case-creator.url}")
     protected String queueUrl;
 
     @Before


### PR DESCRIPTION
As the service could potentially be used going forward for many types of
case creation. This change replaces the properties with a more generic
name.