### PR TITLE
HOCS-4421: use custom clone for branch sha

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -12,6 +12,7 @@ services:
       DEFAULT_REGION: eu-west-2
 
 steps:
+
   - name: setup localstack
     image: quay.io/ukhomeofficedigital/localstack # need curl which is not in alpine
     commands:
@@ -59,7 +60,6 @@ steps:
       registry: quay.io
       repo: quay.io/ukhomeofficedigital/hocs-case-creator
       tags:
-        - build_${DRONE_BUILD_NUMBER}
         - ${DRONE_COMMIT_SHA}
         - branch-${DRONE_COMMIT_BRANCH/\//_}
     environment:
@@ -84,7 +84,6 @@ steps:
       registry: quay.io
       repo: quay.io/ukhomeofficedigital/hocs-case-creator
       tags:
-        - build_${DRONE_BUILD_NUMBER}
         - ${DRONE_COMMIT_SHA}
         - latest
     environment:
@@ -117,6 +116,8 @@ trigger:
     exclude:
       - pull_request
       - tag
+clone:
+  disable: true
 
 services:
   - name: docker
@@ -126,6 +127,11 @@ environment:
   DOCKER_HOST: tcp://docker:2375
 
 steps:
+  - name: clone
+    image: alpine/git
+    commands:
+      - git clone https://github.com/UKHomeOffice/hocs-case-creator.git .
+      - git checkout $${VERSION}
 
   - name: deploy to cs-dev
     image: quay.io/ukhomeofficedigital/kd:v1.16.0
@@ -137,7 +143,7 @@ steps:
       KUBE_TOKEN:
         from_secret: hocs_case_creator_cs_dev
       KUBE_SERVER: https://kube-api-notprod.notprod.acp.homeoffice.gov.uk
-      VERSION: build_${DRONE_BUILD_NUMBER}
+      VERSION: ${DRONE_COMMIT_SHA}
       CLUSTER_NAME: acp-notprod
     when:
       branch:
@@ -189,8 +195,6 @@ steps:
   - name: deploy to cs-qa
     image: quay.io/ukhomeofficedigital/kd:v1.16.0
     commands:
-      - source version.txt
-      - echo $VERSION
       - cd kube
       - ./deploy.sh
     environment:

--- a/kube/deploy.sh
+++ b/kube/deploy.sh
@@ -6,6 +6,11 @@ export KUBE_SERVER=${KUBE_SERVER}
 export KUBE_TOKEN=${KUBE_TOKEN}
 export VERSION=${VERSION}
 
+echo
+echo "Deploying hocs-case-creator to ${ENVIRONMENT}"
+echo "Service version: ${VERSION}"
+echo
+
 if [[ ${KUBE_NAMESPACE} == *prod ]]
 then
     export CASE_CREATOR_UKVI_COMPLAINT_USER="TBD"


### PR DESCRIPTION
At the minute we always use the latest version of the code for promoting
to different environments. While this is not an issue in normal cases,
when a change to the deployment config happens this can throw it out of
line. This change ensures that we always check the corresponding branch
out linked to the release, ensuring that we use the config from that
point in time.

This involves disabling the default clone step and adding a custom one
that for pushes uses the global DRONE_COMMIT_SHA environment variable
and VERSION for deployments. By default, if VERSION isn't applicable git
defaults to the head of the main branch on origin. We now promote the
build SHA for this service between environments instead of the build
number/ semvar tag. The semvar tagging infrastructure is still present
to ensure git repositories still have a point of time release.