### PR TITLE
HOCS-4438: send Channel with case creation

### DIFF
--- a/src/main/java/uk/gov/digital/ho/hocs/queue/complaints/ComplaintService.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/queue/complaints/ComplaintService.java
@@ -20,6 +20,7 @@ public class ComplaintService {
 
     public static final String CORRESPONDENTS_LABEL = "Correspondents";
     public static final String COMPLAINT_TYPE_LABEL = "ComplaintType";
+    public static final String CHANNEL_LABEL = "Channel";
     public static final String ORIGINAL_FILENAME = "WebFormContent.txt";
     public static final String DOCUMENT_TYPE = "To document";
     private final WorkflowClient workflowClient;
@@ -69,6 +70,7 @@ public class ComplaintService {
 
             Map<String, String> data = new HashMap<>();
             data.put(COMPLAINT_TYPE_LABEL, complaintData.getComplaintType());
+            data.put(CHANNEL_LABEL, complaintTypeData.getOrigin());
 
             List<ComplaintCorrespondent> correspondentsList = complaintData.getComplaintCorrespondent();
             if (!correspondentsList.isEmpty()) {

--- a/src/main/java/uk/gov/digital/ho/hocs/queue/complaints/ComplaintTypeData.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/queue/complaints/ComplaintTypeData.java
@@ -2,4 +2,5 @@ package uk.gov.digital.ho.hocs.queue.complaints;
 
 public interface ComplaintTypeData {
     String getCaseType();
+    String getOrigin();
 }

--- a/src/main/java/uk/gov/digital/ho/hocs/queue/complaints/ukvi/UKVITypeData.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/queue/complaints/ukvi/UKVITypeData.java
@@ -9,4 +9,10 @@ public class UKVITypeData implements ComplaintTypeData {
     public String getCaseType() {
         return "COMP";
     }
+
+    @Override
+    public String getOrigin() {
+        return "Webform";
+    }
+
 }

--- a/src/test/java/uk/gov/digital/ho/hocs/queue/complaints/ComplaintServiceTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/queue/complaints/ComplaintServiceTest.java
@@ -146,8 +146,10 @@ public class ComplaintServiceTest {
     }
 
     @Test
-    public void createComplaintWithoutCorrespondentShouldSendType() {
-        Map<String, String> caseData  = Collections.singletonMap("ComplaintType", "EXISTING");
+    public void createComplaintWithoutCorrespondentShouldSendTypeAndChannel() {
+        Map<String, String> caseData  = Map.of(
+                "ComplaintType", "EXISTING",
+                "Channel", "Webform");
 
         goodSetup();
         when(workflowClient.createCase(any(CreateCaseRequest.class))).thenReturn(createCaseResponse);


### PR DESCRIPTION
Change to send the origin ('Channel') with the initial case data
creation packet. This change defaults the option on DECS to this value
for cases that have been created through the webform.