### PR TITLE
HOCS-4280: fix value pass through

### DIFF
--- a/src/main/java/uk/gov/digital/ho/hocs/queue/complaints/ukvi/UKVIComplaintMessageHandler.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/queue/complaints/ukvi/UKVIComplaintMessageHandler.java
@@ -14,7 +14,7 @@ public class UKVIComplaintMessageHandler extends BaseMessageHandler {
     private final UKVIComplaintValidator ukviComplaintValidator;
 
     public UKVIComplaintMessageHandler(
-            @Value("messages.ignored-types") List<String> ignoredMessageTypes,
+            @Value("${message.ignored-types}") List<String> ignoredMessageTypes,
             UKVIComplaintService ukviComplaintService,
             UKVIComplaintValidator ukviComplaintValidator
     ) {


### PR DESCRIPTION
Fix the `Value` for the ignored messages types to use correct SPEL
implementation for reading from the properties file.