### PR TITLE
Repoint Production Secret

### DIFF
--- a/kube/deploy.sh
+++ b/kube/deploy.sh
@@ -13,8 +13,10 @@ echo
 
 if [[ ${KUBE_NAMESPACE} == *prod ]]
 then
+    export SQS_SECRET_NAME="${ENVIRONMENT}-case-creator-sqs"
     export UPTIME_PERIOD="Mon-Sun 05:10-22:50 Europe/London"
 else
+    export SQS_SECRET_NAME="${ENVIRONMENT}-ukvi-complaint-sqs"
     export UPTIME_PERIOD="Mon-Fri 08:10-17:50 Europe/London"
 fi
 

--- a/kube/kd/deployment.yaml
+++ b/kube/kd/deployment.yaml
@@ -174,17 +174,17 @@ spec:
             - name: AWS_SQS_CASE_CREATOR_ACCOUNT_ACCESS_KEY
               valueFrom:
                 secretKeyRef:
-                  name: {{.KUBE_NAMESPACE}}-ukvi-complaint-sqs
+                  name: {{.SQS_SECRET_NAME}}
                   key: access_key_id
             - name: AWS_SQS_CASE_CREATOR_ACCOUNT_SECRET_KEY
               valueFrom:
                 secretKeyRef:
-                  name: {{.KUBE_NAMESPACE}}-ukvi-complaint-sqs
+                  name: {{.SQS_SECRET_NAME}}
                   key: secret_access_key
             - name: AWS_SQS_CASE_CREATOR_URL
               valueFrom:
                 secretKeyRef:
-                  name: {{.KUBE_NAMESPACE}}-ukvi-complaint-sqs
+                  name: {{.SQS_SECRET_NAME}}
                   key: sqs_url
             - name: INFO_NAMESPACE
               valueFrom:


### PR DESCRIPTION
At present, we have a separate 'new' queue in production that is held in
a different secret. This change points the deployment to the new secret
in production environments. This should be removed when ACP add the new
queue config to our not-production environments.