### PR TITLE
HOCS-4278: repoint not-production secret

### DIFF
--- a/kube/deploy.sh
+++ b/kube/deploy.sh
@@ -13,10 +13,8 @@ echo
 
 if [[ ${KUBE_NAMESPACE} == *prod ]]
 then
-    export SQS_SECRET_NAME="${ENVIRONMENT}-case-creator-sqs"
     export UPTIME_PERIOD="Mon-Sun 05:10-22:50 Europe/London"
 else
-    export SQS_SECRET_NAME="${ENVIRONMENT}-ukvi-complaint-sqs"
     export UPTIME_PERIOD="Mon-Fri 08:10-17:50 Europe/London"
 fi
 

--- a/kube/kd/deployment.yaml
+++ b/kube/kd/deployment.yaml
@@ -174,17 +174,17 @@ spec:
             - name: AWS_SQS_CASE_CREATOR_ACCOUNT_ACCESS_KEY
               valueFrom:
                 secretKeyRef:
-                  name: {{.SQS_SECRET_NAME}}
+                  name: {{.KUBE_NAMESPACE}}-case-creator-sqs
                   key: access_key_id
             - name: AWS_SQS_CASE_CREATOR_ACCOUNT_SECRET_KEY
               valueFrom:
                 secretKeyRef:
-                  name: {{.SQS_SECRET_NAME}}
+                  name: {{.KUBE_NAMESPACE}}-case-creator-sqs
                   key: secret_access_key
             - name: AWS_SQS_CASE_CREATOR_URL
               valueFrom:
                 secretKeyRef:
-                  name: {{.SQS_SECRET_NAME}}
+                  name: {{.KUBE_NAMESPACE}}-case-creator-sqs
                   key: sqs_url
             - name: INFO_NAMESPACE
               valueFrom:


### PR DESCRIPTION
Since ACP have added the new queues to the not-production environment,
this change removes the differing not-prod/prod secret pointing in
favour of the single one.