### PR TITLE
HOCS-4440: send through initial case data

### DIFF
--- a/src/main/java/uk/gov/digital/ho/hocs/client/workflow/dto/CreateCaseRequest.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/client/workflow/dto/CreateCaseRequest.java
@@ -8,6 +8,7 @@ import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Map;
 
 @AllArgsConstructor
 @NoArgsConstructor
@@ -23,5 +24,8 @@ public class CreateCaseRequest {
 
     @JsonProperty("documents")
     private List<DocumentSummary> documents;
+
+    @JsonProperty("data")
+    private Map<String, String> data;
 
 }

--- a/src/test/java/uk/gov/digital/ho/hocs/client/workflow/WorkflowClientTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/client/workflow/WorkflowClientTest.java
@@ -43,7 +43,7 @@ public class WorkflowClientTest {
         String s3ObjectName = "8bdc5724-80e4-4fe3-a0a9-1f00262107b0";
         String caseType = "COMP";
         DocumentSummary documentSummary = new DocumentSummary(ORIGINAL_FILENAME, DOCUMENT_TYPE, s3ObjectName);
-        CreateCaseRequest request = new CreateCaseRequest(caseType, LocalDate.of(2021, 1, 1), List.of(documentSummary));
+        CreateCaseRequest request = new CreateCaseRequest(caseType, LocalDate.of(2021, 1, 1), List.of(documentSummary), Map.of());
 
         CreateCaseResponse expectedResponse = new CreateCaseResponse(responseUUID, caseRef);
         ResponseEntity<CreateCaseResponse> responseEntity = new ResponseEntity<>(expectedResponse, HttpStatus.OK);

--- a/src/test/java/uk/gov/digital/ho/hocs/queue/complaints/ComplaintServiceTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/queue/complaints/ComplaintServiceTest.java
@@ -69,7 +69,7 @@ public class ComplaintServiceTest {
         primaryCorrespondent = UUID.randomUUID();
         complaintTypeData = new UKVITypeData();
         DocumentSummary documentSummary = new DocumentSummary(ORIGINAL_FILENAME, DOCUMENT_TYPE, s3ObjectName);
-        createCaseRequest = new CreateCaseRequest(complaintTypeData.getCaseType(), receivedDate, List.of(documentSummary));
+        createCaseRequest = new CreateCaseRequest(complaintTypeData.getCaseType(), receivedDate, List.of(documentSummary), Map.of("ComplaintType", "POOR_STAFF_BEHAVIOUR", "Channel", "Webform"));
         createCaseResponse = new CreateCaseResponse(caseUUID, decsReference);
         user = UUID.randomUUID().toString();
         when(clientContext.getUserId()).thenReturn(user);
@@ -143,20 +143,5 @@ public class ComplaintServiceTest {
         goodSetup();
         when(caseworkClient.getPrimaryCorrespondent(caseUUID)).thenThrow(new NullPointerException());
         complaintService.createComplaint(new UKVIComplaintData(json), complaintTypeData);
-    }
-
-    @Test
-    public void createComplaintWithoutCorrespondentShouldSendTypeAndChannel() {
-        Map<String, String> caseData  = Map.of(
-                "ComplaintType", "EXISTING",
-                "Channel", "Webform");
-
-        goodSetup();
-        when(workflowClient.createCase(any(CreateCaseRequest.class))).thenReturn(createCaseResponse);
-
-        var noCorrespondentJsonString = getResourceFileAsString("existingNoCorrespondent.json");
-        complaintService.createComplaint(new UKVIComplaintData(noCorrespondentJsonString), complaintTypeData);
-
-        verify(caseworkClient).updateCase(any(), any(), eq(caseData));
     }
 }


### PR DESCRIPTION
When a case is first created there is a period of time whereby the case
doing have the required data for the Workflow process to process the
case correctly. As we know at the start the complaint type and channel
this can be sent and processed. This allows us to drive the user
experience based on the case is a WebForm.