### PR TITLE
HOCS-4462: pass through originated from data

### DIFF
--- a/src/main/java/uk/gov/digital/ho/hocs/queue/complaints/ComplaintService.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/queue/complaints/ComplaintService.java
@@ -23,6 +23,7 @@ public class ComplaintService {
     public static final String CHANNEL_LABEL = "Channel";
     public static final String ORIGINAL_FILENAME = "WebFormContent.txt";
     public static final String DOCUMENT_TYPE = "To document";
+    public static final String ORIGINATED_FROM_LABEL = "XOriginatedFrom";
     private final WorkflowClient workflowClient;
     private final CaseworkClient caseworkClient;
     private final ClientContext clientContext;
@@ -94,7 +95,8 @@ public class ComplaintService {
     private CreateCaseRequest composeCreateCaseRequest(ComplaintData complaintData, ComplaintTypeData complaintTypeData, DocumentSummary documentSummary) {
         Map<String, String> initialData = Map.of(
                 COMPLAINT_TYPE_LABEL, complaintData.getComplaintType(),
-                CHANNEL_LABEL, complaintTypeData.getOrigin());
+                CHANNEL_LABEL, complaintTypeData.getOrigin(),
+                ORIGINATED_FROM_LABEL, complaintTypeData.getOrigin());
 
         return new CreateCaseRequest(complaintTypeData.getCaseType(), complaintData.getDateReceived(), List.of(documentSummary), initialData);
     }

--- a/src/test/java/uk/gov/digital/ho/hocs/queue/complaints/ComplaintServiceTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/queue/complaints/ComplaintServiceTest.java
@@ -69,7 +69,13 @@ public class ComplaintServiceTest {
         primaryCorrespondent = UUID.randomUUID();
         complaintTypeData = new UKVITypeData();
         DocumentSummary documentSummary = new DocumentSummary(ORIGINAL_FILENAME, DOCUMENT_TYPE, s3ObjectName);
-        createCaseRequest = new CreateCaseRequest(complaintTypeData.getCaseType(), receivedDate, List.of(documentSummary), Map.of("ComplaintType", "POOR_STAFF_BEHAVIOUR", "Channel", "Webform"));
+
+        var initialCaseData = Map.of(
+                "ComplaintType", "POOR_STAFF_BEHAVIOUR",
+                "Channel", "Webform",
+                "XOriginatedFrom", "Webform");
+
+        createCaseRequest = new CreateCaseRequest(complaintTypeData.getCaseType(), receivedDate, List.of(documentSummary), initialCaseData);
         createCaseResponse = new CreateCaseResponse(caseUUID, decsReference);
         user = UUID.randomUUID().toString();
         when(clientContext.getUserId()).thenReturn(user);


### PR DESCRIPTION
To allow for the workflow process to detour based on WebForm cases we
need a non-modifiable field that indicates that the case came from the
service. This change adds a 'XOriginatedFrom' data value that is used to
drive process behaviour.