### PR TITLE
HOCS-4280: mark UKVI_COMPLAINTS as ignored in prod

### DIFF
--- a/kube/deploy.sh
+++ b/kube/deploy.sh
@@ -14,6 +14,7 @@ echo
 if [[ ${KUBE_NAMESPACE} == *prod ]]
 then
     export UPTIME_PERIOD="Mon-Sun 05:10-22:50 Europe/London"
+    export MESSAGE_IGNORED_TYPES=UKVI_COMPLAINTS
 else
     export UPTIME_PERIOD="Mon-Fri 08:10-17:50 Europe/London"
 fi

--- a/kube/kd/deployment.yaml
+++ b/kube/kd/deployment.yaml
@@ -225,6 +225,8 @@ spec:
                 secretKeyRef:
                   name: hocs-case-creator-identities
                   key: complaint_ukvi_team
+            - name: MESSAGE_IGNORED_TYPES
+              value: {{.MESSAGE_IGNORED_TYPES}}
           resources:
             limits:
               cpu: 1600m

--- a/src/main/java/uk/gov/digital/ho/hocs/queue/common/BaseMessageHandler.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/queue/common/BaseMessageHandler.java
@@ -1,19 +1,26 @@
 package uk.gov.digital.ho.hocs.queue.common;
 
+import lombok.extern.slf4j.Slf4j;
+
 import java.util.List;
 
+@Slf4j
 public abstract class BaseMessageHandler implements MessageHandler {
 
-    private final List<String> ignoredMessageTypes;
+    private final boolean shouldIgnoreMessage;
 
     protected BaseMessageHandler(List<String> ignoredMessageTypes) {
-        this.ignoredMessageTypes = ignoredMessageTypes;
+        shouldIgnoreMessage = ignoredMessageTypes.stream()
+                .map(String::toUpperCase)
+                .anyMatch(messageType -> messageType.equals(getMessageType().getType().toUpperCase()));
+
+        if (shouldIgnoreMessage) {
+            log.info("{} message type flagged for ignoring.", getMessageType().getType());
+        }
     }
 
     public boolean shouldIgnoreMessage() {
-        return ignoredMessageTypes.stream()
-                .map(String::toUpperCase)
-                .anyMatch(messageType -> messageType.equals(getMessageType().getType().toUpperCase()));
+        return shouldIgnoreMessage;
     }
 
 }


### PR DESCRIPTION
Currently, `UKVI_COMPLAINTS` messages should be ignored within
production environments. This change passes this through the deployment
config.
This change also simplifies the `shouldIgnoreMessage` flag to be
calculated only on instantiation rather than every call as this is set
at initial runtime.