### PR TITLE
HOCS-4280: pass empty MESSAGE_IGNORED_TYPE

### DIFF
--- a/kube/deploy.sh
+++ b/kube/deploy.sh
@@ -17,6 +17,7 @@ then
     export MESSAGE_IGNORED_TYPES=UKVI_COMPLAINTS
 else
     export UPTIME_PERIOD="Mon-Fri 08:10-17:50 Europe/London"
+    export MESSAGE_IGNORED_TYPES=''
 fi
 
 export MIN_REPLICAS="1"


### PR DESCRIPTION
Pass through an empty MESSAGE_IGNORED_TYPES for not prod environments as
kd templating requires it to be present but set to empty.