### PR TITLE
HOCS-4672: pass SemVer tag to QA on release

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -196,6 +196,8 @@ steps:
   - name: deploy to cs-qa
     image: quay.io/ukhomeofficedigital/kd:v1.19.13
     commands:
+      - source version.txt
+      - echo $VERSION
       - cd kube
       - ./deploy.sh
     environment:


### PR DESCRIPTION
When a new SemVer version is minted and tagged - we aren't deploying
this tag to the environments. Instead we are setting it to the Git SHA -
this is out of line with other services and confusing for the release
team.