### PR TITLE
HOCS-4696: use GitHub SemVer actions

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,8 +1,13 @@
 ---
-
 kind: pipeline
 type: kubernetes
 name: build
+trigger:
+  event:
+    - push
+  branch:
+    exclude:
+      - main
 
 services:
   - name: localstack
@@ -12,7 +17,6 @@ services:
       DEFAULT_REGION: eu-west-2
 
 steps:
-
   - name: setup localstack
     image: quay.io/ukhomeofficedigital/localstack
     commands:
@@ -22,22 +26,10 @@ steps:
     depends_on:
       - clone
 
-  - name: build project
+  - name: build and test project
     image: quay.io/ukhomeofficedigital/hocs-base-image-build
     commands:
-      - ./gradlew clean assemble
-    environment:
-      ARTIFACTORY_TOKEN:
-        from_secret: ARTIFACTORY_TOKEN
-      ARTIFACTORY_USER:
-        from_secret: ARTIFACTORY_USER
-    depends_on:
-      - setup localstack
-
-  - name: test project
-    image: quay.io/ukhomeofficedigital/hocs-base-image-build
-    commands:
-      - ./gradlew check
+      - ./gradlew clean build --no-daemon
     environment:
       ARTIFACTORY_TOKEN:
         from_secret: ARTIFACTORY_TOKEN
@@ -45,14 +37,14 @@ steps:
         from_secret: ARTIFACTORY_USER
       LOCALSTACK_CONFIG_HOST: "localstack"
     depends_on:
-      - build project
+      - setup localstack
 
   - name: sonar scanner
     image: quay.io/ukhomeofficedigital/sonar-scanner
     commands:
       - sonar-scanner -Dsonar.projectVersion="$(git rev-parse --abbrev-ref HEAD)"
     depends_on:
-      - test project
+      - build and test project
 
   - name: build & push
     image: plugins/docker
@@ -65,63 +57,16 @@ steps:
       DOCKER_PASSWORD:
         from_secret: QUAY_ROBOT_TOKEN
       DOCKER_USERNAME: ukhomeofficedigital+hocs_quay_robot
-      ARTIFACTORY_TOKEN:
-        from_secret: ARTIFACTORY_TOKEN
-      ARTIFACTORY_USER:
-        from_secret: ARTIFACTORY_USER
-    when:
-      branch:
-        exclude:
-          - main
-          - "dependabot*"
     depends_on:
-      - test project
-
-  - name: build & push latest
-    image: plugins/docker
-    settings:
-      registry: quay.io
-      repo: quay.io/ukhomeofficedigital/hocs-case-creator
-      tags:
-        - ${DRONE_COMMIT_SHA}
-        - latest
-    environment:
-      DOCKER_PASSWORD:
-        from_secret: QUAY_ROBOT_TOKEN
-      DOCKER_USERNAME: ukhomeofficedigital+hocs_quay_robot
-      ARTIFACTORY_TOKEN:
-        from_secret: ARTIFACTORY_TOKEN
-      ARTIFACTORY_USER:
-        from_secret: ARTIFACTORY_USER
-    when:
-      branch:
-        include:
-          - main
-    depends_on:
-      - test project
-
-trigger:
-  event:
-    - push
+      - build and test project
 
 ---
 kind: pipeline
 type: kubernetes
 name: deploy
-depends_on:
-  - build
 trigger:
   event:
-    exclude:
-      - pull_request
-      - tag
-
-services:
-  - name: docker
-    image: 340268328991.dkr.ecr.eu-west-2.amazonaws.com/acp/dind
-
-environment:
-  DOCKER_HOST: tcp://docker:2375
+    - promote
 
 steps:
   - name: fetch and checkout
@@ -130,73 +75,9 @@ steps:
       - git fetch --tags
       - git checkout $${VERSION}
 
-  - name: deploy to cs-dev
-    image: quay.io/ukhomeofficedigital/kd
-    commands:
-      - cd kube
-      - ./deploy.sh
-    environment:
-      ENVIRONMENT: cs-dev
-      KUBE_TOKEN:
-        from_secret: hocs_case_creator_cs_dev
-      KUBE_SERVER: https://kube-api-notprod.notprod.acp.homeoffice.gov.uk
-      VERSION: "${DRONE_COMMIT_SHA}"
-      CLUSTER_NAME: acp-notprod
-    depends_on:
-      - fetch and checkout
-    when:
-      branch:
-        - main
-      event:
-        - push
-
-  - name: wait for docker
-    image: docker
-    commands:
-      - n=0; until docker stats --no-stream; do echo "Waiting for Docker $n"; n=$((n +1)); sleep 1; done
-    when:
-      event:
-        - promote
-      target:
-        - release
-
-  - name: generate & tag build
-    image: quay.io/ukhomeofficedigital/hocs-version-bot:latest
-    commands:
-      - >
-        /app/hocs-deploy
-        --dockerRepository=quay.io/ukhomeofficedigital
-        --environment=qa
-        --registryPassword=$${DOCKER_PASSWORD}
-        --registryUser=ukhomeofficedigital+hocs_quay_robot
-        --service=hocs-case-creator
-        --serviceGitToken=$${GITHUB_TOKEN}
-        --sourceBuild=$${VERSION}
-        --version=$${SEMVER}
-        --versionRepo="https://gitlab.digital.homeoffice.gov.uk/hocs/hocs-versions.git"
-        --versionRepoServiceToken=$${GITLAB_TOKEN}
-    environment:
-      DOCKER_API_VERSION: 1.40
-      DOCKER_PASSWORD:
-        from_secret: QUAY_ROBOT_TOKEN
-      GITLAB_TOKEN:
-        from_secret: GITLAB_TOKEN
-      GITHUB_TOKEN:
-        from_secret: GITHUB_TOKEN
-    depends_on:
-      - wait for docker
-      - fetch and checkout
-    when:
-      event:
-        - promote
-      target:
-        - release
-
   - name: deploy to cs-qa
     image: quay.io/ukhomeofficedigital/kd
     commands:
-      - source version.txt
-      - echo $VERSION
       - cd kube
       - ./deploy.sh
     environment:
@@ -206,12 +87,27 @@ steps:
       KUBE_SERVER: https://kube-api-notprod.notprod.acp.homeoffice.gov.uk
       CLUSTER_NAME: acp-notprod
     when:
-      event:
-        - promote
       target:
         - release
     depends_on:
-      - generate & tag build
+      - fetch and checkout
+
+  - name: deploy to wcs-qa
+    image: quay.io/ukhomeofficedigital/kd
+    commands:
+      - cd kube
+      - ./deploy.sh
+    environment:
+      ENVIRONMENT: wcs-qa
+      KUBE_TOKEN:
+        from_secret: hocs_case_creator_wcs_qa
+      KUBE_SERVER: https://kube-api-notprod.notprod.acp.homeoffice.gov.uk
+      CLUSTER_NAME: acp-notprod
+    when:
+      target:
+        - release
+    depends_on:
+      - fetch and checkout
 
   - name: deploy to not prod
     image: quay.io/ukhomeofficedigital/kd
@@ -227,8 +123,6 @@ steps:
     depends_on:
       - fetch and checkout
     when:
-      event:
-        - promote
       target:
         exclude:
           - release
@@ -248,8 +142,110 @@ steps:
     depends_on:
       - fetch and checkout
     when:
-      event:
-        - promote
       target:
         include:
           - "*-prod"
+
+---
+kind: pipeline
+type: kubernetes
+name: build tag
+trigger:
+  event:
+    - tag
+  branch:
+    - main
+
+services:
+  - name: localstack
+    image: quay.io/ukhomeofficedigital/localstack
+    environment:
+      SERVICES: sqs,s3
+      DEFAULT_REGION: eu-west-2
+
+steps:
+  - name: setup localstack
+    image: quay.io/ukhomeofficedigital/localstack
+    commands:
+      - cd config/localstack
+      - ./1-setup-sqs.sh
+      - ./2-setup-s3.sh
+    depends_on:
+      - clone
+
+  - name: build and test project
+    image: quay.io/ukhomeofficedigital/hocs-base-image-build
+    commands:
+      - ./gradlew clean build --no-daemon
+    environment:
+      ARTIFACTORY_TOKEN:
+        from_secret: ARTIFACTORY_TOKEN
+      ARTIFACTORY_USER:
+        from_secret: ARTIFACTORY_USER
+      LOCALSTACK_CONFIG_HOST: "localstack"
+    depends_on:
+      - setup localstack
+
+  - name: sonar scanner
+    image: quay.io/ukhomeofficedigital/sonar-scanner
+    commands:
+      - sonar-scanner -Dsonar.projectVersion="$(git rev-parse --abbrev-ref HEAD)"
+    depends_on:
+      - build and test project
+
+  - name: build & push latest
+    image: plugins/docker
+    settings:
+      registry: quay.io
+      repo: quay.io/ukhomeofficedigital/hocs-case-creator
+      tags:
+        - ${DRONE_TAG}
+        - ${DRONE_COMMIT_SHA}
+        - latest
+    environment:
+      DOCKER_PASSWORD:
+        from_secret: QUAY_ROBOT_TOKEN
+      DOCKER_USERNAME: ukhomeofficedigital+hocs_quay_robot
+    depends_on:
+      - build and test project
+
+---
+kind: pipeline
+type: kubernetes
+name: deploy tag
+trigger:
+  event:
+    - tag
+  branch:
+    - main
+depends_on:
+  - build tag
+
+steps:
+  - name: deploy to cs-dev
+    image: quay.io/ukhomeofficedigital/kd
+    commands:
+      - cd kube
+      - ./deploy.sh
+    environment:
+      ENVIRONMENT: cs-dev
+      KUBE_TOKEN:
+        from_secret: hocs_case_creator_cs_dev
+      KUBE_SERVER: https://kube-api-notprod.notprod.acp.homeoffice.gov.uk
+      VERSION: "${DRONE_TAG}"
+    depends_on:
+      - clone
+
+  - name: deploy to wcs-dev
+    image: quay.io/ukhomeofficedigital/kd
+    commands:
+      - cd kube
+      - ./deploy.sh
+    environment:
+      ENVIRONMENT: wcs-dev
+      KUBE_TOKEN:
+        from_secret: hocs_case_creator_wcs_dev
+      KUBE_SERVER: https://kube-api-notprod.notprod.acp.homeoffice.gov.uk
+      VERSION: "${DRONE_TAG}"
+    depends_on:
+      - clone

--- a/.github/workflows/label-check.yml
+++ b/.github/workflows/label-check.yml
@@ -1,0 +1,14 @@
+name: 'PR Label Checker'
+on:
+  pull_request:
+    types: [ labeled, unlabeled, opened, reopened, synchronize ]
+
+jobs:
+  build:
+    name: SemVer PR Label Checker
+    runs-on: ubuntu-latest
+    steps:
+      - uses: UKHomeOffice/match-label-action@v1.0.0
+        with:
+          labels: minor,major,patch
+          mode: singular

--- a/.github/workflows/semver.yml
+++ b/.github/workflows/semver.yml
@@ -1,0 +1,20 @@
+name: 'SemVer - Tag the Commit'
+on:
+  pull_request:
+    types: [ closed ]
+
+jobs:
+  build:
+    name: SemVer Tag on PR Merge
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.merged == true && github.base_ref == 'main'
+    steps:
+      - id: label
+        uses: UKHomeOffice/match-label-action@v1.0.0
+        with:
+          labels: minor,major,patch
+          mode: singular
+      - uses: UKHomeOffice/semver-tag-action@v1.0.0
+        with:
+          increment: ${{ steps.label.outputs.matchedLabels }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -83,3 +83,7 @@ the build as a dependency in the gradle file.
 
 For local development, build the schema locally and publish
 to a Maven local repository. View the README in `hocs-ukvi-complaint-schema` for more information.
+
+## License
+
+This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.


### PR DESCRIPTION
This change removes the use of the old `hocs-version-bot` in favour of
new GitHub actions.

When an action happens on a PR an action is run that checks that the PR
is labeled with one of the following: `Patch`, `Minor`, or `Major`.
If one of these isn't present the PR will be blocked till one is added.
This enables us to immediately identify the scale of the change.

On an successful merge, an second action is ran that uses specified
label to update the SemVer version for the service - automatically
creating a Git Tag with that version.

This triggers a drone build that automatically deploys this new version
to the dev environments.