### PR TITLE
HOCS-4696: Override Dependabot labels

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,6 @@ updates:
         separator: "-"
       reviewers:
         - "UKHomeOffice/hocs-core"
+      labels:
+        - "patch"
+        - "dependencies"


### PR DESCRIPTION
Since adding the semver labels Dependabot has been adding 'Major', 'Minor' or 'Patch' labels on its PRs according the semver bump on the library it is updating.
We want it to add 'patch' regardless as from our perspective the change is a patch change to the service.