### PR TITLE
HOCS-5140: action failure slack integration

### DIFF
--- a/.github/workflows/semver.yml
+++ b/.github/workflows/semver.yml
@@ -20,3 +20,12 @@ jobs:
           increment: ${{ steps.label.outputs.matchedLabels }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           default_use_head_tag: ${{ github.base_ref == 'main' }}
+      - name: Post failure to Slack channel
+        id: slack
+        uses: slackapi/slack-github-action@v1.19.0
+        if: ${{ failure() && steps.*.conclusion == 'failure' }}
+        with:
+          channel-id: ${{ secrets.SLACK_CHANNEL_ID }}
+          slack-message: "GitHub Action failure: ${{github.repository}}\nRun: ${{github.server_url}}/${{github.repository}}/actions/runs/${{github.run_id}}\nOriginating PR: ${{ github.event.pull_request.html_url || github.event.head_commit.url }}"
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}

--- a/.github/workflows/semver.yml
+++ b/.github/workflows/semver.yml
@@ -14,7 +14,7 @@ jobs:
         with:
           labels: minor,major,patch,skip-release
           mode: singular
-      - uses: UKHomeOffice/semver-tag-action@v2.1.1
+      - uses: UKHomeOffice/semver-tag-action@v2
         if: contains(steps.label.outputs.matchedLabels, 'skip-release') == false
         with:
           increment: ${{ steps.label.outputs.matchedLabels }}


### PR DESCRIPTION
When a GitHub job fails there is currently know way of identifying this,
this change sends a notification to a channel of our choosing to flag
that there is an issue that needs looking at.

To simplify upgrades to the action - this change pegs the version to the
latest major tag `v2` in this instance.