### PR TITLE
HOCS-5180: use GHP rather than Artifactory

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -31,10 +31,8 @@ steps:
     commands:
       - ./gradlew clean build --no-daemon
     environment:
-      ARTIFACTORY_TOKEN:
-        from_secret: ARTIFACTORY_TOKEN
-      ARTIFACTORY_USER:
-        from_secret: ARTIFACTORY_USER
+      PACKAGE_TOKEN:
+        from_secret: PACKAGE_TOKEN
       LOCALSTACK_CONFIG_HOST: "localstack"
     depends_on:
       - setup localstack
@@ -162,10 +160,8 @@ steps:
     commands:
       - ./gradlew clean build --no-daemon
     environment:
-      ARTIFACTORY_TOKEN:
-        from_secret: ARTIFACTORY_TOKEN
-      ARTIFACTORY_USER:
-        from_secret: ARTIFACTORY_USER
+      PACKAGE_TOKEN:
+        from_secret: PACKAGE_TOKEN
       LOCALSTACK_CONFIG_HOST: "localstack"
     depends_on:
       - setup localstack

--- a/build.gradle
+++ b/build.gradle
@@ -14,10 +14,10 @@ repositories {
     mavenCentral()
     mavenLocal()
     maven {
-        url 'https://artifactory.digital.homeoffice.gov.uk/artifactory/DECS/'
+        url = "https://maven.pkg.github.com/UKHomeOffice/hocs-ukvi-complaint-schema"
         credentials {
-            username System.getenv('ARTIFACTORY_USER')
-            password System.getenv('ARTIFACTORY_TOKEN')
+            username = "Anonymous"
+            password = System.getenv("PACKAGE_TOKEN")
         }
     }
 }
@@ -52,8 +52,9 @@ dependencies {
 
     implementation 'net.logstash.logback:logstash-logback-encoder:7.2'
 
-    implementation 'uk.gov.digital.ho.hocs:hocs-ukvi-complaint-schema:1.0.0'
+    implementation 'uk.gov.digital.ho.hocs:hocs-ukvi-complaint-schema:1.0.1'
 
+    implementation 'com.networknt:json-schema-validator:1.0.70'
     implementation 'com.jayway.jsonpath:json-path:2.7.0'
     implementation 'javax.xml.bind:jaxb-api:2.3.1'
     implementation 'org.apache.commons:commons-text:1.9'


### PR DESCRIPTION
Use the GitHub Package for the UKVI schema rather than a private facing
Artifactory instance. This will allow improved future changes that
require a publicly available package store.