### PR TITLE
Migration deployment

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -230,3 +230,34 @@ steps:
       VERSION: "${DRONE_TAG}"
     depends_on:
       - clone
+
+---
+kind: pipeline
+type: kubernetes
+name: migration deploy tag
+trigger:
+  event:
+    - tag
+  branch:
+    - main
+depends_on:
+  - build tag
+
+steps:
+  - name: deploy migrator to cs-dev
+    image: quay.io/ukhomeofficedigital/kd
+    commands:
+      - cd kube
+      - ./deploy.sh
+    environment:
+      ENVIRONMENT: cs-dev
+      DEPLOYMENT_TYPE: migrator
+      SQS_SECRET_NAME: case-migrator-sqs
+      CASE_CREATOR_PORT: 10943
+      KUBE_TOKEN:
+        from_secret: hocs_case_creator_cs_dev
+      KUBE_SERVER: https://kube-api-notprod.notprod.acp.homeoffice.gov.uk
+      CLUSTER_NAME: acp-notprod
+      VERSION: "${DRONE_TAG}"
+    depends_on:
+      - clone

--- a/kube/deploy.sh
+++ b/kube/deploy.sh
@@ -6,6 +6,8 @@ export KUBE_SERVER=${KUBE_SERVER}
 export KUBE_TOKEN=${KUBE_TOKEN}
 export VERSION=${VERSION}
 export CLUSTER_NAME=${CLUSTER_NAME}
+export DEPLOYMENT_TYPE="creator"
+export SQS_SECRET_NAME="case-creator-sqs"
 
 echo
 echo "Deploying hocs-case-creator to ${ENVIRONMENT}"
@@ -16,9 +18,11 @@ if [[ ${KUBE_NAMESPACE} == *prod ]]
 then
     export UPTIME_PERIOD="Mon-Sun 05:10-22:50 Europe/London"
     export MESSAGE_IGNORED_TYPES=UKVI_COMPLAINTS
+    export MIGRATION="false"
 else
     export UPTIME_PERIOD="Mon-Fri 08:10-17:50 Europe/London"
     export MESSAGE_IGNORED_TYPES=''
+    export MIGRATION="true"
 fi
 
 export MIN_REPLICAS="1"
@@ -32,3 +36,11 @@ kd --timeout 10m \
     -f deployment.yaml \
     -f service.yaml \
     -f autoscale.yaml
+
+if [[ ${MIGRATION} == "true" ]]
+then
+  DEPLOYMENT_TYPE="migrator"
+  SQS_SECRET_NAME="case-migrator-sqs"
+  kd --timeout 10m \
+      -f deployment.yaml
+fi

--- a/kube/deploy.sh
+++ b/kube/deploy.sh
@@ -45,5 +45,6 @@ then
   export PORT=10943
   kd --timeout 10m \
       -f deployment.yaml \
+      -f service.yaml \
       -f autoscale.yaml
 fi

--- a/kube/deploy.sh
+++ b/kube/deploy.sh
@@ -38,6 +38,8 @@ kd --timeout 10m \
 
 if [[ ${KUBE_NAMESPACE} == *dev* ]]
 then
+  echo "Deploying hocs-case-migrator to ${ENVIRONMENT}"
+  echo "Service version: ${VERSION}"
   export DEPLOYMENT_TYPE="migrator"
   export SQS_SECRET_NAME="case-migrator-sqs"
   export PORT=10943

--- a/kube/deploy.sh
+++ b/kube/deploy.sh
@@ -8,6 +8,7 @@ export VERSION=${VERSION}
 export CLUSTER_NAME=${CLUSTER_NAME}
 export DEPLOYMENT_TYPE="creator"
 export SQS_SECRET_NAME="case-creator-sqs"
+export PORT=10443
 
 echo
 echo "Deploying hocs-case-creator to ${ENVIRONMENT}"
@@ -37,8 +38,10 @@ kd --timeout 10m \
 
 if [[ ${KUBE_NAMESPACE} == *dev* ]]
 then
-  DEPLOYMENT_TYPE="migrator"
-  SQS_SECRET_NAME="case-migrator-sqs"
+  export DEPLOYMENT_TYPE="migrator"
+  export SQS_SECRET_NAME="case-migrator-sqs"
+  export PORT=10943
   kd --timeout 10m \
-      -f deployment.yaml
+      -f deployment.yaml \
+      -f autoscale.yaml
 fi

--- a/kube/deploy.sh
+++ b/kube/deploy.sh
@@ -18,11 +18,9 @@ if [[ ${KUBE_NAMESPACE} == *prod ]]
 then
     export UPTIME_PERIOD="Mon-Sun 05:10-22:50 Europe/London"
     export MESSAGE_IGNORED_TYPES=UKVI_COMPLAINTS
-    export MIGRATION="false"
 else
     export UPTIME_PERIOD="Mon-Fri 08:10-17:50 Europe/London"
     export MESSAGE_IGNORED_TYPES=''
-    export MIGRATION="true"
 fi
 
 export MIN_REPLICAS="1"
@@ -37,7 +35,7 @@ kd --timeout 10m \
     -f service.yaml \
     -f autoscale.yaml
 
-if [[ ${MIGRATION} == "true" ]]
+if [[ ${KUBE_NAMESPACE} == *dev* ]]
 then
   DEPLOYMENT_TYPE="migrator"
   SQS_SECRET_NAME="case-migrator-sqs"

--- a/kube/deploy.sh
+++ b/kube/deploy.sh
@@ -11,7 +11,7 @@ export SQS_SECRET_NAME=${SQS_SECRET_NAME:-case-creator-sqs}
 export PORT=${CASE_CREATOR_PORT:-10443}
 
 echo
-echo "Deploying hocs-case-creator to ${ENVIRONMENT}"
+echo "Deploying hocs-case-${DEPLOYMENT_TYPE} to ${ENVIRONMENT}"
 echo "Service version: ${VERSION}"
 echo
 

--- a/kube/deploy.sh
+++ b/kube/deploy.sh
@@ -6,9 +6,9 @@ export KUBE_SERVER=${KUBE_SERVER}
 export KUBE_TOKEN=${KUBE_TOKEN}
 export VERSION=${VERSION}
 export CLUSTER_NAME=${CLUSTER_NAME}
-export DEPLOYMENT_TYPE="creator"
-export SQS_SECRET_NAME="case-creator-sqs"
-export PORT=10443
+export DEPLOYMENT_TYPE=${DEPLOYMENT_TYPE:-creator}
+export SQS_SECRET_NAME=${SQS_SECRET_NAME:-case-creator-sqs}
+export PORT=${CASE_CREATOR_PORT:-10443}
 
 echo
 echo "Deploying hocs-case-creator to ${ENVIRONMENT}"
@@ -36,15 +36,3 @@ kd --timeout 10m \
     -f service.yaml \
     -f autoscale.yaml
 
-if [[ ${KUBE_NAMESPACE} == *dev* ]]
-then
-  echo "Deploying hocs-case-migrator to ${ENVIRONMENT}"
-  echo "Service version: ${VERSION}"
-  export DEPLOYMENT_TYPE="migrator"
-  export SQS_SECRET_NAME="case-migrator-sqs"
-  export PORT=10943
-  kd --timeout 10m \
-      -f deployment.yaml \
-      -f service.yaml \
-      -f autoscale.yaml
-fi

--- a/kube/kd/autoscale.yaml
+++ b/kube/kd/autoscale.yaml
@@ -2,13 +2,13 @@ apiVersion: autoscaling/v1
 kind: HorizontalPodAutoscaler
 metadata:
   labels:
-    app: hocs-case-creator
-  name: hocs-case-creator
+    app: hocs-case-{{.DEPLOYMENT_TYPE}}
+  name: hocs-case-{{.DEPLOYMENT_TYPE}}
 spec:
   maxReplicas: {{.MAX_REPLICAS}}
   minReplicas: {{.MIN_REPLICAS}}
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment
-    name: hocs-case-creator
+    name: hocs-case-{{.DEPLOYMENT_TYPE}}
   targetCPUUtilizationPercentage: 70

--- a/kube/kd/deployment.yaml
+++ b/kube/kd/deployment.yaml
@@ -136,7 +136,7 @@ spec:
               readOnly: true
           ports:
             - name: https
-              containerPort: 10443
+              containerPort: {{.PORT}}
           resources:
             limits:
               memory: 96Mi

--- a/kube/kd/deployment.yaml
+++ b/kube/kd/deployment.yaml
@@ -2,7 +2,7 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: hocs-case-creator
+  name: hocs-case-{{.DEPLOYMENT_TYPE}}
   labels:
     version: {{.VERSION}}
   annotations:
@@ -11,7 +11,7 @@ spec:
   replicas: {{.MIN_REPLICAS}}
   selector:
     matchLabels:
-      name: hocs-case-creator
+      name: hocs-case-{{.DEPLOYMENT_TYPE}}
   strategy:
     rollingUpdate:
       maxUnavailable: 50%
@@ -20,7 +20,7 @@ spec:
   template:
     metadata:
       labels:
-        name: hocs-case-creator
+        name: hocs-case-{{.DEPLOYMENT_TYPE}}
         role: hocs-backend
         version: {{.VERSION}}
     spec:
@@ -174,17 +174,17 @@ spec:
             - name: AWS_SQS_CASE_CREATOR_ACCOUNT_ACCESS_KEY
               valueFrom:
                 secretKeyRef:
-                  name: {{.KUBE_NAMESPACE}}-case-creator-sqs
+                  name: {{.KUBE_NAMESPACE}}-{{.SQS_SECRET_NAME}}
                   key: access_key_id
             - name: AWS_SQS_CASE_CREATOR_ACCOUNT_SECRET_KEY
               valueFrom:
                 secretKeyRef:
-                  name: {{.KUBE_NAMESPACE}}-case-creator-sqs
+                  name: {{.KUBE_NAMESPACE}}-{{.SQS_SECRET_NAME}}
                   key: secret_access_key
             - name: AWS_SQS_CASE_CREATOR_URL
               valueFrom:
                 secretKeyRef:
-                  name: {{.KUBE_NAMESPACE}}-case-creator-sqs
+                  name: {{.KUBE_NAMESPACE}}-{{.SQS_SECRET_NAME}}
                   key: sqs_url
             - name: INFO_NAMESPACE
               valueFrom:

--- a/kube/kd/service.yaml
+++ b/kube/kd/service.yaml
@@ -9,6 +9,6 @@ spec:
   ports:
   - name: https
     port: 443
-    targetPort: 10443
+    targetPort: {{.PORT}}
   selector:
     name: hocs-case-creator

--- a/kube/kd/service.yaml
+++ b/kube/kd/service.yaml
@@ -3,8 +3,8 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    name: hocs-case-creator
-  name: hocs-case-creator
+    name: hocs-case-{{.DEPLOYMENT_TYPE}}
+  name: hocs-case-{{.DEPLOYMENT_TYPE}}
 spec:
   ports:
   - name: https


### PR DESCRIPTION
This a change to customise the deployment for case-creator into the cs-dev namespace.

Please refer to this [migration](https://collaboration.homeoffice.gov.uk/display/HOCS/Migration+of+cases+from+external+systems+to+DECS) page in confluence.

We are deploying an instance of case-creator to connect to the Migration SQS queue. It will pick up the SQS details from a separate secret in the namespace. It will have a different name hocs-case-migrator.

The default values are for a normal deployment of hocs-case creator. The values are modified from the pipeline to create a hocs-case-migrator deployment.

