### PR TITLE
HOCS-4765: update schema version dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,7 +32,7 @@ dependencies {
 
     implementation 'net.logstash.logback:logstash-logback-encoder:7.2'
 
-    implementation 'uk.gov.digital.ho.hocs:hocs-ukvi-complaint-schema:1.0.1'
+    implementation 'uk.gov.digital.ho.hocs:hocs-ukvi-complaint-schema:1.1.1'
 
     implementation 'com.networknt:json-schema-validator:1.0.72'
     implementation 'com.jayway.jsonpath:json-path:2.7.0'


### PR DESCRIPTION
Update the `hocs-ukvi-complaint-schema` dependency to 1.1.1.