### PR TITLE
HOCS 5583 - Extract correspondent information from migration message

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,8 +32,9 @@ dependencies {
 
     implementation 'net.logstash.logback:logstash-logback-encoder:7.2'
 
+
     implementation 'uk.gov.digital.ho.hocs:hocs-ukvi-complaint-schema:1.2.0'
-    implementation 'uk.gov.digital.ho.hocs:hocs-migration-schema:0.4.0'
+    implementation 'uk.gov.digital.ho.hocs:hocs-migration-schema:0.5.0'
 
     implementation 'com.networknt:json-schema-validator:1.0.73'
     implementation 'com.jayway.jsonpath:json-path:2.7.0'

--- a/src/main/java/uk/gov/digital/ho/hocs/client/migration/casework/dto/CreateMigrationCaseRequest.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/client/migration/casework/dto/CreateMigrationCaseRequest.java
@@ -4,11 +4,8 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
-import lombok.NoArgsConstructor;
-import uk.gov.digital.ho.hocs.client.casework.dto.ComplaintCorrespondent;
 import uk.gov.digital.ho.hocs.client.workflow.dto.DocumentSummary;
 
-import javax.validation.constraints.NotNull;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Map;
@@ -35,5 +32,4 @@ public class CreateMigrationCaseRequest {
 
     @JsonProperty("primaryCorrespondent")
     private MigrationComplaintCorrespondent primaryCorrespondent;
-
 }

--- a/src/main/java/uk/gov/digital/ho/hocs/client/migration/casework/dto/CreateMigrationCaseRequest.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/client/migration/casework/dto/CreateMigrationCaseRequest.java
@@ -33,6 +33,7 @@ public class CreateMigrationCaseRequest {
     @JsonProperty("stageType")
     private String stageType;
 
-    @JsonProperty("complaintCorrespondents")
-    private List<ComplaintCorrespondent> complaintCorrespondents;
+    @JsonProperty("primaryCorrespondent")
+    private MigrationComplaintCorrespondent primaryCorrespondent;
+
 }

--- a/src/main/java/uk/gov/digital/ho/hocs/client/migration/casework/dto/CreateMigrationCaseRequest.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/client/migration/casework/dto/CreateMigrationCaseRequest.java
@@ -5,6 +5,7 @@ import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import uk.gov.digital.ho.hocs.client.casework.dto.ComplaintCorrespondent;
 import uk.gov.digital.ho.hocs.client.workflow.dto.DocumentSummary;
 
 import javax.validation.constraints.NotNull;
@@ -31,4 +32,7 @@ public class CreateMigrationCaseRequest {
 
     @JsonProperty("stageType")
     private String stageType;
+
+    @JsonProperty("complaintCorrespondents")
+    private List<ComplaintCorrespondent> complaintCorrespondents;
 }

--- a/src/main/java/uk/gov/digital/ho/hocs/client/migration/casework/dto/MigrationComplaintCorrespondent.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/client/migration/casework/dto/MigrationComplaintCorrespondent.java
@@ -1,0 +1,61 @@
+package uk.gov.digital.ho.hocs.client.migration.casework.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.lang.NonNull;
+import uk.gov.digital.ho.hocs.queue.complaints.CorrespondentType;
+
+import javax.validation.constraints.NotEmpty;
+
+
+@Getter
+@Setter
+@AllArgsConstructor
+@EqualsAndHashCode
+public class MigrationComplaintCorrespondent {
+
+    @NonNull
+    @NotEmpty
+    @JsonProperty(value = "fullName", required = true)
+    String fullname;
+
+    @NonNull
+    @NotEmpty
+    @JsonProperty(value = "correspondentType", required = true)
+    CorrespondentType type;
+
+    @JsonProperty("telephone")
+    String telephone;
+
+    @JsonProperty("email")
+    String email;
+
+    @JsonProperty("organisation")
+    String organisation;
+
+    @JsonProperty("address1")
+    String address1;
+
+    @JsonProperty("address2")
+    String address2;
+
+    @JsonProperty("address3")
+    String address3;
+
+    @JsonProperty("postcode")
+    String postcode;
+
+    @JsonProperty("country")
+    String country;
+
+    @JsonProperty("reference")
+    String reference;
+
+    public MigrationComplaintCorrespondent(@NonNull @NotEmpty  String fullname, @NonNull @NotEmpty CorrespondentType type) {
+        this.type = type;
+        this.fullname = fullname;
+    }
+}

--- a/src/main/java/uk/gov/digital/ho/hocs/client/migration/casework/dto/MigrationComplaintCorrespondent.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/client/migration/casework/dto/MigrationComplaintCorrespondent.java
@@ -1,10 +1,7 @@
 package uk.gov.digital.ho.hocs.client.migration.casework.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import lombok.AllArgsConstructor;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.Setter;
+import lombok.*;
 import org.springframework.lang.NonNull;
 import uk.gov.digital.ho.hocs.queue.complaints.CorrespondentType;
 
@@ -14,27 +11,19 @@ import javax.validation.constraints.NotEmpty;
 @Getter
 @Setter
 @AllArgsConstructor
+@NoArgsConstructor
 @EqualsAndHashCode
 public class MigrationComplaintCorrespondent {
 
     @NonNull
     @NotEmpty
     @JsonProperty(value = "fullName", required = true)
-    String fullname;
+    String fullName;
 
     @NonNull
     @NotEmpty
     @JsonProperty(value = "correspondentType", required = true)
-    CorrespondentType type;
-
-    @JsonProperty("telephone")
-    String telephone;
-
-    @JsonProperty("email")
-    String email;
-
-    @JsonProperty("organisation")
-    String organisation;
+    CorrespondentType correspondentType;
 
     @JsonProperty("address1")
     String address1;
@@ -51,11 +40,20 @@ public class MigrationComplaintCorrespondent {
     @JsonProperty("country")
     String country;
 
+    @JsonProperty("organisation")
+    String organisation;
+
+    @JsonProperty("telephone")
+    String telephone;
+
+    @JsonProperty("email")
+    String email;
+
     @JsonProperty("reference")
     String reference;
 
-    public MigrationComplaintCorrespondent(@NonNull @NotEmpty  String fullname, @NonNull @NotEmpty CorrespondentType type) {
-        this.type = type;
-        this.fullname = fullname;
+    public MigrationComplaintCorrespondent(@NonNull @NotEmpty  String fullName, @NonNull @NotEmpty CorrespondentType type) {
+        this.correspondentType = type;
+        this.fullName = fullName;
     }
 }

--- a/src/main/java/uk/gov/digital/ho/hocs/queue/migration/MigrationData.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/queue/migration/MigrationData.java
@@ -1,12 +1,11 @@
 package uk.gov.digital.ho.hocs.queue.migration;
 
-import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
 import uk.gov.digital.ho.hocs.client.casework.dto.ComplaintCorrespondent;
-import uk.gov.digital.ho.hocs.client.migration.casework.dto.MigrationComplaintCorrespondent;
 import uk.gov.digital.ho.hocs.queue.data.CaseData;
 
+import java.util.LinkedHashMap;
 import java.util.List;
 
 @Slf4j
@@ -29,13 +28,5 @@ public class MigrationData extends CaseData {
         return null;
     }
 
-    public MigrationComplaintCorrespondent getPrimaryCorrespondent() {
-        ObjectMapper objectMapper = new ObjectMapper();
-        MigrationComplaintCorrespondent correspondent = objectMapper.convertValue(
-                ctx.read(PRIMARY_CORRESPONDENT),
-                new TypeReference<>() {
-        });
-        return correspondent;
-    }
-
+    public LinkedHashMap getPrimaryCorrespondent() { return ctx.read(PRIMARY_CORRESPONDENT); }
 }

--- a/src/main/java/uk/gov/digital/ho/hocs/queue/migration/MigrationData.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/queue/migration/MigrationData.java
@@ -2,9 +2,9 @@ package uk.gov.digital.ho.hocs.queue.migration;
 
 import lombok.extern.slf4j.Slf4j;
 import uk.gov.digital.ho.hocs.client.casework.dto.ComplaintCorrespondent;
+import uk.gov.digital.ho.hocs.queue.complaints.CorrespondentType;
 import uk.gov.digital.ho.hocs.queue.data.CaseData;
 
-import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -12,6 +12,7 @@ import java.util.List;
 public class MigrationData extends CaseData {
 
     private static final String COMPLAINT_TYPE = "$.caseType";
+    private static final String COMPLAINT_CORRESPONDENT_FULLNAME = "$.correspondentName";
 
     public MigrationData(String jsonBody) {
         super(jsonBody);
@@ -23,12 +24,13 @@ public class MigrationData extends CaseData {
     }
 
     /**
-     * Returns an empty list for now. Will add the logic once we received the data.
-     * @return
+     *  This assumes only one correspondent per migration message. To verify once we received the data.
+     *  @return a list of correspondent objects
      */
     @Override
     public List<ComplaintCorrespondent> getComplaintCorrespondent() {
         List<ComplaintCorrespondent> correspondents = new ArrayList<>();
+        correspondents.add(new ComplaintCorrespondent(ctx.read(COMPLAINT_CORRESPONDENT_FULLNAME), CorrespondentType.COMPLAINANT));
         return correspondents;
     }
 

--- a/src/main/java/uk/gov/digital/ho/hocs/queue/migration/MigrationData.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/queue/migration/MigrationData.java
@@ -1,7 +1,10 @@
 package uk.gov.digital.ho.hocs.queue.migration;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
 import uk.gov.digital.ho.hocs.client.casework.dto.ComplaintCorrespondent;
+import uk.gov.digital.ho.hocs.client.migration.casework.dto.MigrationComplaintCorrespondent;
 import uk.gov.digital.ho.hocs.queue.data.CaseData;
 
 import java.util.List;
@@ -26,9 +29,13 @@ public class MigrationData extends CaseData {
         return null;
     }
 
-
-    public String getPrimaryCorrespondent() {
-        return ctx.read(PRIMARY_CORRESPONDENT).toString();
+    public MigrationComplaintCorrespondent getPrimaryCorrespondent() {
+        ObjectMapper objectMapper = new ObjectMapper();
+        MigrationComplaintCorrespondent correspondent = objectMapper.convertValue(
+                ctx.read(PRIMARY_CORRESPONDENT),
+                new TypeReference<>() {
+        });
+        return correspondent;
     }
 
 }

--- a/src/main/java/uk/gov/digital/ho/hocs/queue/migration/MigrationData.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/queue/migration/MigrationData.java
@@ -1,18 +1,22 @@
 package uk.gov.digital.ho.hocs.queue.migration;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import lombok.extern.slf4j.Slf4j;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import uk.gov.digital.ho.hocs.client.casework.dto.ComplaintCorrespondent;
+import uk.gov.digital.ho.hocs.client.migration.casework.dto.MigrationComplaintCorrespondent;
 import uk.gov.digital.ho.hocs.queue.complaints.CorrespondentType;
 import uk.gov.digital.ho.hocs.queue.data.CaseData;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 
 @Slf4j
 public class MigrationData extends CaseData {
 
     private static final String COMPLAINT_TYPE = "$.caseType";
-    private static final String COMPLAINT_CORRESPONDENT_FULLNAME = "$.correspondentName";
+    private static final String PRIMARY_CORRESPONDENT = "$.primaryCorrespondent";
 
     public MigrationData(String jsonBody) {
         super(jsonBody);
@@ -23,15 +27,18 @@ public class MigrationData extends CaseData {
         return ctx.read(COMPLAINT_TYPE);
     }
 
+    @Override
+    public List<ComplaintCorrespondent> getComplaintCorrespondent() {
+        return null;
+    }
+
     /**
      *  This assumes only one correspondent per migration message. To verify once we received the data.
      *  @return a list of correspondent objects
      */
-    @Override
-    public List<ComplaintCorrespondent> getComplaintCorrespondent() {
-        List<ComplaintCorrespondent> correspondents = new ArrayList<>();
-        correspondents.add(new ComplaintCorrespondent(ctx.read(COMPLAINT_CORRESPONDENT_FULLNAME), CorrespondentType.COMPLAINANT));
-        return correspondents;
+
+    public String getPrimaryCorrespondent() {
+        return ctx.read(PRIMARY_CORRESPONDENT).toString();
     }
 
 }

--- a/src/main/java/uk/gov/digital/ho/hocs/queue/migration/MigrationData.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/queue/migration/MigrationData.java
@@ -1,15 +1,9 @@
 package uk.gov.digital.ho.hocs.queue.migration;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import lombok.extern.slf4j.Slf4j;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import uk.gov.digital.ho.hocs.client.casework.dto.ComplaintCorrespondent;
-import uk.gov.digital.ho.hocs.client.migration.casework.dto.MigrationComplaintCorrespondent;
-import uk.gov.digital.ho.hocs.queue.complaints.CorrespondentType;
 import uk.gov.digital.ho.hocs.queue.data.CaseData;
 
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 
 @Slf4j
@@ -32,10 +26,6 @@ public class MigrationData extends CaseData {
         return null;
     }
 
-    /**
-     *  This assumes only one correspondent per migration message. To verify once we received the data.
-     *  @return a list of correspondent objects
-     */
 
     public String getPrimaryCorrespondent() {
         return ctx.read(PRIMARY_CORRESPONDENT).toString();

--- a/src/main/java/uk/gov/digital/ho/hocs/queue/migration/MigrationService.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/queue/migration/MigrationService.java
@@ -13,10 +13,8 @@ import uk.gov.digital.ho.hocs.client.migration.casework.dto.MigrationComplaintCo
 import uk.gov.digital.ho.hocs.client.workflow.WorkflowClient;
 import uk.gov.digital.ho.hocs.client.workflow.dto.DocumentSummary;
 
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 
 @Slf4j
 @Service
@@ -54,7 +52,7 @@ public class MigrationService {
     private CreateMigrationCaseRequest composeMigrateCaseRequest(MigrationData migrationData, MigrationCaseTypeData migrationCaseTypeData, DocumentSummary documentSummary) {
         Map<String, String> initialData = Map.of(CHANNEL_LABEL, migrationCaseTypeData.getOrigin());
 
-        MigrationComplaintCorrespondent primaryCorrespondent = getPrimaryCorrespondent(migrationData.getPrimaryCorrespondent());
+        MigrationComplaintCorrespondent primaryCorrespondent = migrationData.getPrimaryCorrespondent();
 
         return new CreateMigrationCaseRequest(migrationData.getComplaintType(),
                 migrationData.getDateReceived(),
@@ -63,18 +61,4 @@ public class MigrationService {
                 "MIGRATION",
                 primaryCorrespondent);
     }
-
-    private MigrationComplaintCorrespondent getPrimaryCorrespondent(String json) {
-        MigrationComplaintCorrespondent[] correspondents;
-        try {
-            correspondents = objectMapper.readValue(json, MigrationComplaintCorrespondent[].class);
-        } catch (JsonProcessingException e) {
-            throw new RuntimeException(e);
-        }
-        if (correspondents.length > 1) {
-            // TODO: Create Exception
-        }
-        return correspondents[0];
-    }
-
 }

--- a/src/main/java/uk/gov/digital/ho/hocs/queue/migration/MigrationService.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/queue/migration/MigrationService.java
@@ -47,7 +47,7 @@ public class MigrationService {
     private CreateMigrationCaseRequest composeMigrateCaseRequest(MigrationData migrationData, MigrationCaseTypeData migrationCaseTypeData, DocumentSummary documentSummary) {
         Map<String, String> initialData = Map.of(CHANNEL_LABEL, migrationCaseTypeData.getOrigin());
 
-        return new CreateMigrationCaseRequest(migrationData.getComplaintType(), migrationData.getDateReceived(), List.of(documentSummary), initialData, "MIGRATION");
+        return new CreateMigrationCaseRequest(migrationData.getComplaintType(), migrationData.getDateReceived(), List.of(documentSummary), initialData, "MIGRATION", migrationData.getComplaintCorrespondent());
     }
 
 }

--- a/src/main/java/uk/gov/digital/ho/hocs/queue/migration/MigrationService.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/queue/migration/MigrationService.java
@@ -1,6 +1,7 @@
 package uk.gov.digital.ho.hocs.queue.migration;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -13,6 +14,7 @@ import uk.gov.digital.ho.hocs.client.migration.casework.dto.MigrationComplaintCo
 import uk.gov.digital.ho.hocs.client.workflow.WorkflowClient;
 import uk.gov.digital.ho.hocs.client.workflow.dto.DocumentSummary;
 
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -52,7 +54,8 @@ public class MigrationService {
     private CreateMigrationCaseRequest composeMigrateCaseRequest(MigrationData migrationData, MigrationCaseTypeData migrationCaseTypeData, DocumentSummary documentSummary) {
         Map<String, String> initialData = Map.of(CHANNEL_LABEL, migrationCaseTypeData.getOrigin());
 
-        MigrationComplaintCorrespondent primaryCorrespondent = migrationData.getPrimaryCorrespondent();
+
+        MigrationComplaintCorrespondent primaryCorrespondent = getPrimaryCorrespondent(migrationData.getPrimaryCorrespondent());
 
         return new CreateMigrationCaseRequest(migrationData.getComplaintType(),
                 migrationData.getDateReceived(),
@@ -61,4 +64,13 @@ public class MigrationService {
                 "MIGRATION",
                 primaryCorrespondent);
     }
+
+    public MigrationComplaintCorrespondent getPrimaryCorrespondent(LinkedHashMap correspondentJson) {
+        MigrationComplaintCorrespondent primaryCorrespondent = objectMapper.convertValue(
+                correspondentJson,
+                new TypeReference<>() {
+                });
+        return primaryCorrespondent;
+    }
+
 }

--- a/src/main/java/uk/gov/digital/ho/hocs/queue/migration/MigrationService.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/queue/migration/MigrationService.java
@@ -1,18 +1,22 @@
 package uk.gov.digital.ho.hocs.queue.migration;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import uk.gov.digital.ho.hocs.application.ClientContext;
-import uk.gov.digital.ho.hocs.client.casework.CaseworkClient;
 import uk.gov.digital.ho.hocs.client.casework.dto.CreateCaseworkCaseResponse;
 import uk.gov.digital.ho.hocs.client.migration.casework.MigrationCaseworkClient;
 import uk.gov.digital.ho.hocs.client.migration.casework.dto.CreateMigrationCaseRequest;
 import uk.gov.digital.ho.hocs.client.document.DocumentS3Client;
+import uk.gov.digital.ho.hocs.client.migration.casework.dto.MigrationComplaintCorrespondent;
 import uk.gov.digital.ho.hocs.client.workflow.WorkflowClient;
 import uk.gov.digital.ho.hocs.client.workflow.dto.DocumentSummary;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 @Slf4j
 @Service
@@ -25,18 +29,21 @@ public class MigrationService {
     private final ClientContext clientContext;
     private final DocumentS3Client documentS3Client;
 
+    private final ObjectMapper objectMapper;
+
     public MigrationService(WorkflowClient workflowClient,
                             MigrationCaseworkClient migrationCaseworkClient,
                             ClientContext clientContext,
-                            DocumentS3Client documentS3Client) {
+                            DocumentS3Client documentS3Client,
+                            ObjectMapper objectMapper) {
         this.workflowClient = workflowClient;
         this.migrationCaseworkClient = migrationCaseworkClient;
         this.clientContext = clientContext;
         this.documentS3Client = documentS3Client;
+        this.objectMapper = objectMapper;
     }
 
     public void createMigrationCase(MigrationData migrationCaseData, MigrationCaseTypeData migrationCaseTypeData) {
-
         // dummy documents list
         DocumentSummary documentSummary = new DocumentSummary("migration","","");
         var migrationRequest = composeMigrateCaseRequest(migrationCaseData, migrationCaseTypeData, documentSummary);
@@ -47,7 +54,27 @@ public class MigrationService {
     private CreateMigrationCaseRequest composeMigrateCaseRequest(MigrationData migrationData, MigrationCaseTypeData migrationCaseTypeData, DocumentSummary documentSummary) {
         Map<String, String> initialData = Map.of(CHANNEL_LABEL, migrationCaseTypeData.getOrigin());
 
-        return new CreateMigrationCaseRequest(migrationData.getComplaintType(), migrationData.getDateReceived(), List.of(documentSummary), initialData, "MIGRATION", migrationData.getComplaintCorrespondent());
+        MigrationComplaintCorrespondent primaryCorrespondent = getPrimaryCorrespondent(migrationData.getPrimaryCorrespondent());
+
+        return new CreateMigrationCaseRequest(migrationData.getComplaintType(),
+                migrationData.getDateReceived(),
+                List.of(documentSummary),
+                initialData,
+                "MIGRATION",
+                primaryCorrespondent);
+    }
+
+    private MigrationComplaintCorrespondent getPrimaryCorrespondent(String json) {
+        MigrationComplaintCorrespondent[] correspondents;
+        try {
+            correspondents = objectMapper.readValue(json, MigrationComplaintCorrespondent[].class);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+        if (correspondents.length > 1) {
+            // TODO: Create Exception
+        }
+        return correspondents[0];
     }
 
 }

--- a/src/test/java/uk/gov/digital/ho/hocs/client/migration/casework/MigrationCaseworkClientTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/client/migration/casework/MigrationCaseworkClientTest.java
@@ -40,7 +40,7 @@ public class MigrationCaseworkClientTest {
         Map<String, String> data = new HashMap<>();
         LocalDate date = LocalDate.now();
 
-        CreateMigrationCaseRequest request = new CreateMigrationCaseRequest("Migration", date, null, data, "COMP_MIGRATION_END");
+        CreateMigrationCaseRequest request = new CreateMigrationCaseRequest("Migration", date, null, data, "COMP_MIGRATION_END", null);
         CreateCaseworkCaseResponse expectedResponse = new CreateCaseworkCaseResponse(responseUUID, caseRef, data);
         ResponseEntity<CreateCaseworkCaseResponse> responseEntity = new ResponseEntity<>(expectedResponse, HttpStatus.OK);
 

--- a/src/test/java/uk/gov/digital/ho/hocs/queue/migration/MigrationMessageValidatorTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/queue/migration/MigrationMessageValidatorTest.java
@@ -1,0 +1,46 @@
+package uk.gov.digital.ho.hocs.queue.migration;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.test.context.ActiveProfiles;
+import uk.gov.digital.ho.hocs.application.SpringConfiguration;
+import uk.gov.digital.ho.hocs.queue.complaints.ukvi.UKVIComplaintValidator;
+
+import java.util.UUID;
+
+import static uk.gov.digital.ho.hocs.testutil.TestFileReader.getResourceFileAsString;
+
+@ActiveProfiles(profiles = "local")
+@RunWith(MockitoJUnitRunner.class)
+public class MigrationMessageValidatorTest {
+
+    private MigrationMessageValidator migrationMessageValidator;
+
+    private final String messageId = UUID.randomUUID().toString();
+
+    @Before
+    public void setUp() {
+        migrationMessageValidator = new MigrationMessageValidator(
+                new SpringConfiguration().objectMapper());
+    }
+
+    @Test
+    public void shouldValidateWithValidMigrationMessage() throws Exception {
+        var validMessage = getResourceFileAsString("validMigration.json");
+        migrationMessageValidator.validate(validMessage, messageId);
+    }
+
+    @Test(expected = Exception.class)
+    public void shouldValidateWithInvalidMigrationMessageWithMissingPrimaryCorrespondent() throws Exception {
+        var validMessage = getResourceFileAsString("invalidMigrationMissingPrimaryCorrespondent.json");
+        migrationMessageValidator.validate(validMessage, messageId);
+    }
+
+    @Test(expected = Exception.class)
+    public void shouldValidateWithInvalidMigrationMessageWithMissingRequiredFieldsForPrimaryCorrespondent() throws Exception {
+        var validMessage = getResourceFileAsString("invalidMigrationMissingRequiredFields.json");
+        migrationMessageValidator.validate(validMessage, messageId);
+    }
+}

--- a/src/test/java/uk/gov/digital/ho/hocs/queue/migration/MigrationServiceTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/queue/migration/MigrationServiceTest.java
@@ -64,7 +64,8 @@ public class MigrationServiceTest {
         objectMapper = new ObjectMapper();
         migrationService = new MigrationService(workflowClient, migrationCaseworkClient, clientContext, documentS3Client, objectMapper);
 
-        MigrationComplaintCorrespondent primaryCorrespondent = migrationData.getPrimaryCorrespondent();
+        MigrationComplaintCorrespondent primaryCorrespondent = migrationService.getPrimaryCorrespondent(
+                migrationData.getPrimaryCorrespondent());
 
         documentSummary = new DocumentSummary("migration","","");
         createMigrationCaseRequest = new CreateMigrationCaseRequest(migrationData.getComplaintType(),

--- a/src/test/java/uk/gov/digital/ho/hocs/queue/migration/MigrationServiceTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/queue/migration/MigrationServiceTest.java
@@ -83,7 +83,7 @@ public class MigrationServiceTest {
     }
 
     @Test
-    public void GivenAValidMigrationMessageWhenCreatingAMigrationRequestThenMigrationResponseContainsAPrimaryCorrespondent() {
+    public void shouldContainAPrimaryCorrespondent() {
         MigrationComplaintCorrespondent primaryCorrespondents = createMigrationCaseRequest.getPrimaryCorrespondent();
 
         MigrationComplaintCorrespondent expectedPrimaryCorrespondent =
@@ -104,7 +104,7 @@ public class MigrationServiceTest {
     }
 
     @Test(expected= PathNotFoundException.class)
-    public void GivenAnInvalidMigrationMessageWhenCreatingAMigrationRequestThenReturnAnException(){
+    public void shouldFailWithMissingPrimaryCorrespondent(){
         json = getResourceFileAsString("invalidMigrationMissingPrimaryCorrespondent.json");
         migrationData = new MigrationData(json);
         migrationCaseTypeData = new MigrationCaseTypeData();

--- a/src/test/java/uk/gov/digital/ho/hocs/queue/migration/MigrationServiceTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/queue/migration/MigrationServiceTest.java
@@ -7,8 +7,7 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.digital.ho.hocs.application.ClientContext;
-import uk.gov.digital.ho.hocs.client.casework.CaseworkClient;
-import uk.gov.digital.ho.hocs.client.casework.dto.ComplaintCorrespondent;
+
 import uk.gov.digital.ho.hocs.client.casework.dto.CreateCaseworkCaseResponse;
 import uk.gov.digital.ho.hocs.client.migration.casework.MigrationCaseworkClient;
 import uk.gov.digital.ho.hocs.client.migration.casework.dto.CreateMigrationCaseRequest;
@@ -21,10 +20,8 @@ import uk.gov.digital.ho.hocs.queue.complaints.CorrespondentType;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 import static uk.gov.digital.ho.hocs.testutil.TestFileReader.getResourceFileAsString;
@@ -55,7 +52,6 @@ public class MigrationServiceTest {
 
     private DocumentSummary documentSummary;
 
-    @Mock
     private ObjectMapper objectMapper;
 
     @Before
@@ -65,11 +61,18 @@ public class MigrationServiceTest {
         LocalDate receivedDate = LocalDate.parse("2020-10-03");
         migrationCaseTypeData = new MigrationCaseTypeData();
         Map<String, String> initialData = Map.of("Channel", migrationCaseTypeData.getOrigin());
-        //MigrationComplaintCorrespondent primaryCorrespondent = migrationService.
-        documentSummary = new DocumentSummary("migration","","");
-        createMigrationCaseRequest = new CreateMigrationCaseRequest(migrationData.getComplaintType(), migrationData.getDateReceived(), List.of(documentSummary), initialData, "MIGRATION", null);
-        caseworkCaseResponse = new CreateCaseworkCaseResponse();
+        objectMapper = new ObjectMapper();
         migrationService = new MigrationService(workflowClient, migrationCaseworkClient, clientContext, documentS3Client, objectMapper);
+
+        MigrationComplaintCorrespondent primaryCorrespondent = migrationData.getPrimaryCorrespondent();
+
+        documentSummary = new DocumentSummary("migration","","");
+        createMigrationCaseRequest = new CreateMigrationCaseRequest(migrationData.getComplaintType(),
+                migrationData.getDateReceived(), List.of(documentSummary),
+                initialData,
+                "MIGRATION",
+                primaryCorrespondent);
+        caseworkCaseResponse = new CreateCaseworkCaseResponse();
         when(migrationCaseworkClient.migrateCase(any(CreateMigrationCaseRequest.class))).thenReturn(caseworkCaseResponse);
     }
     @Test
@@ -86,17 +89,16 @@ public class MigrationServiceTest {
                 new MigrationComplaintCorrespondent(
                         "fullName",
                         CorrespondentType.COMPLAINANT,
-                        "telephone",
-                        "email",
-                        "organisation",
                         "address1",
                         "address2",
                         "address3",
                         "postcode",
                         "country",
+                        "organisation",
+                        "telephone",
+                        "email",
                         "reference"
                         );
         assertEquals(expectedPrimaryCorrespondent, primaryCorrespondents);
-
     }
 }

--- a/src/test/resources/invalidMigrationMissingPrimaryCorrespondent.json
+++ b/src/test/resources/invalidMigrationMissingPrimaryCorrespondent.json
@@ -1,0 +1,18 @@
+{
+  "caseType": "COMP",
+  "sourceCaseId": "in",
+  "caseStatus": "caseStatus",
+  "caseStatusDate": "1947-02-14",
+  "creationDate": "1965-06-22",
+  "caseData": [
+    {"name": "type", "value": "cms"},
+    {"name": "creationDate", "value": "01/07/2022"}
+  ],
+  "caseAttachments": [
+    {
+      "path": "path",
+      "label": "label",
+      "documentType": "documentType"
+    }
+  ]
+}

--- a/src/test/resources/invalidMigrationMissingRequiredFields.json
+++ b/src/test/resources/invalidMigrationMissingRequiredFields.json
@@ -1,0 +1,29 @@
+{
+  "caseType": "COMP",
+  "sourceCaseId": "in",
+  "primaryCorrespondent": {
+    "address1": "address1",
+    "address2": "address2",
+    "address3": "address3",
+    "postcode": "postcode",
+    "country": "country",
+    "organisation": "organisation",
+    "telephone": "telephone",
+    "email": "email",
+    "reference": "reference"
+  },
+  "caseStatus": "caseStatus",
+  "caseStatusDate": "1947-02-14",
+  "creationDate": "1965-06-22",
+  "caseData": [
+    {"name": "type", "value": "cms"},
+    {"name": "creationDate", "value": "01/07/2022"}
+  ],
+  "caseAttachments": [
+    {
+      "path": "path",
+      "label": "label",
+      "documentType": "documentType"
+    }
+  ]
+}

--- a/src/test/resources/validMigration.json
+++ b/src/test/resources/validMigration.json
@@ -1,8 +1,47 @@
 {
     "caseType": "COMP",
     "sourceCaseId": "in",
-    "correspondentName": "correspondentFullName",
-    "correspondenceEmail": "correspondentEmail",
+    "primaryCorrespondent": {
+      "fullName": "fullName",
+      "correspondentType": "COMPLAINANT",
+      "address1": "address1",
+      "address2": "address2",
+      "address3": "address3",
+      "postcode": "postcode",
+      "country": "country",
+      "organisation": "organisation",
+      "telephone": "telephone",
+      "email": "email",
+      "reference": "reference"
+    },
+    "otherCorrespondents":[
+      {
+        "fullName": "fullName",
+        "correspondentType": "COMPLAINANT",
+        "address1": "address1",
+        "address2": "address2",
+        "address3": "address3",
+        "postcode": "postcode",
+        "country": "country",
+        "organisation": "organisation",
+        "telephone": "telephone",
+        "email": "email",
+        "reference": "reference"
+      },
+      {
+        "fullName": "fullName",
+        "correspondentType": "COMPLAINANT",
+        "address1": "address1",
+        "address2": "address2",
+        "address3": "address3",
+        "postcode": "postcode",
+        "country": "country",
+        "organisation": "organisation",
+        "telephone": "telephone",
+        "email": "email",
+        "reference": "reference"
+      }
+    ],
     "caseStatus": "caseStatus",
     "caseStatusDate": "1947-02-14",
     "creationDate": "1965-06-22",

--- a/src/test/resources/validMigration.json
+++ b/src/test/resources/validMigration.json
@@ -1,59 +1,31 @@
 {
-    "caseType": "COMP",
-    "sourceCaseId": "in",
-    "primaryCorrespondent": {
-      "fullName": "fullName",
-      "correspondentType": "COMPLAINANT",
-      "address1": "address1",
-      "address2": "address2",
-      "address3": "address3",
-      "postcode": "postcode",
-      "country": "country",
-      "organisation": "organisation",
-      "telephone": "telephone",
-      "email": "email",
-      "reference": "reference"
-    },
-    "otherCorrespondents":[
-      {
-        "fullName": "fullName",
-        "correspondentType": "COMPLAINANT",
-        "address1": "address1",
-        "address2": "address2",
-        "address3": "address3",
-        "postcode": "postcode",
-        "country": "country",
-        "organisation": "organisation",
-        "telephone": "telephone",
-        "email": "email",
-        "reference": "reference"
-      },
-      {
-        "fullName": "fullName",
-        "correspondentType": "COMPLAINANT",
-        "address1": "address1",
-        "address2": "address2",
-        "address3": "address3",
-        "postcode": "postcode",
-        "country": "country",
-        "organisation": "organisation",
-        "telephone": "telephone",
-        "email": "email",
-        "reference": "reference"
-      }
-    ],
-    "caseStatus": "caseStatus",
-    "caseStatusDate": "1947-02-14",
-    "creationDate": "1965-06-22",
-    "caseData": [
-      {"name": "type", "value": "cms"},
-      {"name": "creationDate", "value": "01/07/2022"}
-    ],
-    "caseAttachments": [
-      {
-        "path": "path",
-        "label": "label",
-        "documentType": "documentType"
-      }
-    ]
+  "caseType": "COMP",
+  "sourceCaseId": "in",
+  "primaryCorrespondent": {
+    "fullName": "fullName",
+    "correspondentType": "COMPLAINANT",
+    "address1": "address1",
+    "address2": "address2",
+    "address3": "address3",
+    "postcode": "postcode",
+    "country": "country",
+    "organisation": "organisation",
+    "telephone": "telephone",
+    "email": "email",
+    "reference": "reference"
+  },
+  "caseStatus": "caseStatus",
+  "caseStatusDate": "1947-02-14",
+  "creationDate": "1965-06-22",
+  "caseData": [
+    {"name": "type", "value": "cms"},
+    {"name": "creationDate", "value": "01/07/2022"}
+  ],
+  "caseAttachments": [
+    {
+      "path": "path",
+      "label": "label",
+      "documentType": "documentType"
+    }
+  ]
 }

--- a/src/test/resources/validMigration.json
+++ b/src/test/resources/validMigration.json
@@ -1,9 +1,9 @@
 {
     "caseType": "COMP",
     "sourceCaseId": "in",
-    "correspondentName": "Ut incididunt",
-    "correspondenceEmail": "mollit",
-    "caseStatus": "tempor veniam ut laboris nulla",
+    "correspondentName": "correspondentFullName",
+    "correspondenceEmail": "correspondentEmail",
+    "caseStatus": "caseStatus",
     "caseStatusDate": "1947-02-14",
     "creationDate": "1965-06-22",
     "caseData": [
@@ -12,9 +12,9 @@
     ],
     "caseAttachments": [
       {
-        "path": "laborum nisi",
-        "label": "sunt",
-        "documentType": "deserunt laboris anim nisi"
+        "path": "path",
+        "label": "label",
+        "documentType": "documentType"
       }
     ]
 }


### PR DESCRIPTION
Extract correspondent information from migration message, add to casework request to create case with correspondents (and stage respectively).

