### PR TITLE
HOCS-5584: Add migration case attachments

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,7 @@ dependencies {
 
 
     implementation 'uk.gov.digital.ho.hocs:hocs-ukvi-complaint-schema:1.3.0'
-    implementation 'uk.gov.digital.ho.hocs:hocs-migration-schema:0.8.0'
+    implementation 'uk.gov.digital.ho.hocs:hocs-migration-schema:0.10.0'
 
     implementation 'com.networknt:json-schema-validator:1.0.75'
     implementation 'com.jayway.jsonpath:json-path:2.7.0'

--- a/src/main/java/uk/gov/digital/ho/hocs/client/migration/casework/dto/CreateMigrationCaseRequest.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/client/migration/casework/dto/CreateMigrationCaseRequest.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
-import uk.gov.digital.ho.hocs.client.workflow.dto.DocumentSummary;
+import uk.gov.digital.ho.hocs.queue.migration.CaseAttachment;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -21,9 +21,6 @@ public class CreateMigrationCaseRequest {
     @JsonProperty("dateReceived")
     private LocalDate dateReceived;
 
-    @JsonProperty("documents")
-    private List<DocumentSummary> documents;
-
     @JsonProperty("data")
     private Map<String, String> data;
 
@@ -35,4 +32,7 @@ public class CreateMigrationCaseRequest {
 
     @JsonProperty("additionalCorrespondents")
     private List<MigrationComplaintCorrespondent> additionalCorrespondents;
+
+    @JsonProperty("caseAttachments")
+    private List<CaseAttachment> attachments;
 }

--- a/src/main/java/uk/gov/digital/ho/hocs/queue/migration/CaseAttachment.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/queue/migration/CaseAttachment.java
@@ -1,0 +1,23 @@
+package uk.gov.digital.ho.hocs.queue.migration;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@EqualsAndHashCode
+@Getter
+public class CaseAttachment {
+
+    @JsonProperty("displayName")
+    private String displayName;
+
+    @JsonProperty("documentType")
+    private String type;
+
+    @JsonProperty("documentPath")
+    private String documentPath;
+}

--- a/src/main/java/uk/gov/digital/ho/hocs/queue/migration/MigrationData.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/queue/migration/MigrationData.java
@@ -18,6 +18,7 @@ public class MigrationData extends CaseData {
     private static final String COMPLAINT_TYPE = "$.caseType";
     private static final String PRIMARY_CORRESPONDENT = "$.primaryCorrespondent";
     private static final String ADDITIONAL_CORRESPONDENTS = "$.additionalCorrespondents";
+    private static final String CASE_ATTACHMENTS = "$.caseAttachments";
 
     public MigrationData(String jsonBody) {
         super(jsonBody);
@@ -26,6 +27,10 @@ public class MigrationData extends CaseData {
     @Override
     public String getComplaintType() {
         return ctx.read(COMPLAINT_TYPE);
+    }
+
+    public String getCaseAttachments() {
+        return ctx.read(CASE_ATTACHMENTS).toString();
     }
 
     @Override

--- a/src/main/java/uk/gov/digital/ho/hocs/queue/migration/MigrationService.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/queue/migration/MigrationService.java
@@ -83,7 +83,7 @@ public class MigrationService {
         }
     }
 
-    private List<CaseAttachment> getCaseAttachments(String attachments) {
+    public List<CaseAttachment> getCaseAttachments(String attachments) {
         CaseAttachment[] caseAttachments;
         try {
             caseAttachments = objectMapper.readValue(attachments, CaseAttachment[].class);

--- a/src/main/java/uk/gov/digital/ho/hocs/queue/migration/MigrationService.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/queue/migration/MigrationService.java
@@ -1,6 +1,5 @@
 package uk.gov.digital.ho.hocs.queue.migration;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
@@ -83,13 +82,15 @@ public class MigrationService {
         }
     }
 
-    public List<CaseAttachment> getCaseAttachments(String attachments) {
-        CaseAttachment[] caseAttachments;
+    public List<CaseAttachment> getCaseAttachments(String attachmentsJson) {
         try {
-            caseAttachments = objectMapper.readValue(attachments, CaseAttachment[].class);
-        } catch (JsonProcessingException e) {
-            throw new RuntimeException(e);
+            List<CaseAttachment> caseAttachments = objectMapper.convertValue(
+                    objectMapper.readValue(attachmentsJson, JSONArray.class),
+                    new TypeReference<>() {
+                    });
+            return caseAttachments;
+        } catch (Exception e) {
+            return Collections.emptyList();
         }
-        return Arrays.asList(caseAttachments);
     }
 }

--- a/src/main/java/uk/gov/digital/ho/hocs/queue/migration/MigrationService.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/queue/migration/MigrationService.java
@@ -3,10 +3,8 @@ package uk.gov.digital.ho.hocs.queue.migration;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.jayway.jsonpath.JsonPath;
 import lombok.extern.slf4j.Slf4j;
 import net.minidev.json.JSONArray;
-import net.minidev.json.JSONObject;
 import org.springframework.stereotype.Service;
 import uk.gov.digital.ho.hocs.application.ClientContext;
 import uk.gov.digital.ho.hocs.client.casework.dto.CreateCaseworkCaseResponse;
@@ -15,7 +13,6 @@ import uk.gov.digital.ho.hocs.client.migration.casework.dto.CreateMigrationCaseR
 import uk.gov.digital.ho.hocs.client.document.DocumentS3Client;
 import uk.gov.digital.ho.hocs.client.migration.casework.dto.MigrationComplaintCorrespondent;
 import uk.gov.digital.ho.hocs.client.workflow.WorkflowClient;
-import uk.gov.digital.ho.hocs.client.workflow.dto.DocumentSummary;
 
 import java.util.*;
 
@@ -45,26 +42,25 @@ public class MigrationService {
     }
 
     public void createMigrationCase(MigrationData migrationCaseData, MigrationCaseTypeData migrationCaseTypeData) {
-        // dummy documents list
-        DocumentSummary documentSummary = new DocumentSummary("migration","","");
-        var migrationRequest = composeMigrateCaseRequest(migrationCaseData, migrationCaseTypeData, documentSummary);
+        var migrationRequest = composeMigrateCaseRequest(migrationCaseData, migrationCaseTypeData);
         CreateCaseworkCaseResponse caseResponse = migrationCaseworkClient.migrateCase(migrationRequest);
         log.info("Created migration case {}", caseResponse.getUuid());
     }
 
-    private CreateMigrationCaseRequest composeMigrateCaseRequest(MigrationData migrationData, MigrationCaseTypeData migrationCaseTypeData, DocumentSummary documentSummary) {
+    private CreateMigrationCaseRequest composeMigrateCaseRequest(MigrationData migrationData, MigrationCaseTypeData migrationCaseTypeData) {
         Map<String, String> initialData = Map.of(CHANNEL_LABEL, migrationCaseTypeData.getOrigin());
 
         MigrationComplaintCorrespondent primaryCorrespondent = getPrimaryCorrespondent(migrationData.getPrimaryCorrespondent());
         List<MigrationComplaintCorrespondent> additionalCorrespondents = getAdditionalCorrespondents(migrationData.getAdditionalCorrespondents());
+        List<CaseAttachment> caseAttachments = getCaseAttachments(migrationData.getCaseAttachments());
 
         return new CreateMigrationCaseRequest(migrationData.getComplaintType(),
                 migrationData.getDateReceived(),
-                List.of(documentSummary),
                 initialData,
                 "MIGRATION",
                 primaryCorrespondent,
-                additionalCorrespondents);
+                additionalCorrespondents,
+                caseAttachments);
     }
 
     public MigrationComplaintCorrespondent getPrimaryCorrespondent(LinkedHashMap correspondentJson) {
@@ -85,5 +81,15 @@ public class MigrationService {
         } catch (Exception e) {
             return Collections.emptyList();
         }
+    }
+
+    private List<CaseAttachment> getCaseAttachments(String attachments) {
+        CaseAttachment[] caseAttachments;
+        try {
+            caseAttachments = objectMapper.readValue(attachments, CaseAttachment[].class);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException(e);
+        }
+        return Arrays.asList(caseAttachments);
     }
 }

--- a/src/test/java/uk/gov/digital/ho/hocs/client/migration/casework/MigrationCaseworkClientTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/client/migration/casework/MigrationCaseworkClientTest.java
@@ -12,7 +12,6 @@ import uk.gov.digital.ho.hocs.client.casework.dto.CreateCaseworkCaseResponse;
 import uk.gov.digital.ho.hocs.client.migration.casework.dto.CreateMigrationCaseRequest;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
@@ -40,7 +39,15 @@ public class MigrationCaseworkClientTest {
         Map<String, String> data = new HashMap<>();
         LocalDate date = LocalDate.now();
 
-        CreateMigrationCaseRequest request = new CreateMigrationCaseRequest("Migration", date, null, data, "COMP_MIGRATION_END", null, null);
+        CreateMigrationCaseRequest request = new CreateMigrationCaseRequest(
+                "Migration",
+                date,
+                data,
+                "COMP_MIGRATION_END",
+                null,
+                null,
+                null);
+
         CreateCaseworkCaseResponse expectedResponse = new CreateCaseworkCaseResponse(responseUUID, caseRef, data);
         ResponseEntity<CreateCaseworkCaseResponse> responseEntity = new ResponseEntity<>(expectedResponse, HttpStatus.OK);
 

--- a/src/test/java/uk/gov/digital/ho/hocs/queue/common/integration/MigrationQueueListenerIntegrationTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/queue/common/integration/MigrationQueueListenerIntegrationTest.java
@@ -31,4 +31,10 @@ public class MigrationQueueListenerIntegrationTest extends AwsSqsIntegrationTest
         String validMessage = TestFileReader.getResourceFileAsString("validMigrationNoAdditionalCorrespondents.json");
         amazonSQSAsync.sendMessage(migrationQueueUrl, validMessage);
     }
+
+    @Test
+    public void consumeMessageFromMigrationQueueWithNoCaseAttachments() {
+        String validMessage = TestFileReader.getResourceFileAsString("validMigrationNoCaseAttachments.json");
+        amazonSQSAsync.sendMessage(migrationQueueUrl, validMessage);
+    }
 }

--- a/src/test/java/uk/gov/digital/ho/hocs/queue/common/integration/MigrationQueueListenerIntegrationTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/queue/common/integration/MigrationQueueListenerIntegrationTest.java
@@ -37,4 +37,16 @@ public class MigrationQueueListenerIntegrationTest extends AwsSqsIntegrationTest
         String validMessage = TestFileReader.getResourceFileAsString("validMigrationNoCaseAttachments.json");
         amazonSQSAsync.sendMessage(migrationQueueUrl, validMessage);
     }
+
+    @Test
+    public void consumeMessageFromMigrationQueueWithCaseAttachments() {
+        String validMessage = TestFileReader.getResourceFileAsString("validMigrationWithCaseAttachments.json");
+        amazonSQSAsync.sendMessage(migrationQueueUrl, validMessage);
+    }
+
+    @Test
+    public void consumeMessageFromMigrationQueueWithOptionalFieldsNull() {
+        String validMessage = TestFileReader.getResourceFileAsString("validMigrationWithOptionalFieldsNull.json");
+        amazonSQSAsync.sendMessage(migrationQueueUrl, validMessage);
+    }
 }

--- a/src/test/java/uk/gov/digital/ho/hocs/queue/migration/MigrationMessageValidatorTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/queue/migration/MigrationMessageValidatorTest.java
@@ -33,25 +33,37 @@ public class MigrationMessageValidatorTest {
 
     @Test(expected = Exception.class)
     public void shouldNotValidateWithInvalidMigrationMessageWithMissingPrimaryCorrespondent() throws Exception {
-        var validMessage = getResourceFileAsString("invalidMigrationMissingPrimaryCorrespondent.json");
-        migrationMessageValidator.validate(validMessage, messageId);
+        var invalidMessage = getResourceFileAsString("invalidMigrationMissingPrimaryCorrespondent.json");
+        migrationMessageValidator.validate(invalidMessage, messageId);
     }
 
     @Test(expected = Exception.class)
     public void shouldNotValidateWithInvalidMigrationMessageWithMissingRequiredFieldsForPrimaryCorrespondent() throws Exception {
-        var validMessage = getResourceFileAsString("invalidMigrationMissingRequiredFieldsPrimaryCorrespondent.json");
-        migrationMessageValidator.validate(validMessage, messageId);
+        var invalidMessage = getResourceFileAsString("invalidMigrationMissingRequiredFieldsPrimaryCorrespondent.json");
+        migrationMessageValidator.validate(invalidMessage, messageId);
     }
 
     @Test(expected = Exception.class)
     public void shouldNotValidateWithInvalidMigrationMessageWithMissingRequiredFieldsForAdditionalCorrespondent() throws Exception {
-        var validMessage = getResourceFileAsString("invalidMigrationMissingRequiredFieldsAdditionalCorrespondent.json");
-        migrationMessageValidator.validate(validMessage, messageId);
+        var invalidMessage = getResourceFileAsString("invalidMigrationMissingRequiredFieldsAdditionalCorrespondent.json");
+        migrationMessageValidator.validate(invalidMessage, messageId);
     }
 
     @Test
     public void shouldValidateWithNoAdditionalCorrespondents() throws Exception {
         var validMessage = getResourceFileAsString("validMigrationNoAdditionalCorrespondents.json");
+        migrationMessageValidator.validate(validMessage, messageId);
+    }
+
+    @Test(expected = Exception.class)
+    public void shouldNotValidateWithInvalidMigrationMessageWithMissingCaseAttachments() throws Exception {
+        var invalidMessage = getResourceFileAsString("invalidMigrationMessageMissingCaseAttachments.json");
+        migrationMessageValidator.validate(invalidMessage, messageId);
+    }
+
+    @Test
+    public void shouldValidateWithNoCaseAttachments() throws Exception {
+        var validMessage = getResourceFileAsString("validMigrationNoCaseAttachments.json");
         migrationMessageValidator.validate(validMessage, messageId);
     }
 }

--- a/src/test/java/uk/gov/digital/ho/hocs/queue/migration/MigrationMessageValidatorTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/queue/migration/MigrationMessageValidatorTest.java
@@ -66,4 +66,10 @@ public class MigrationMessageValidatorTest {
         var validMessage = getResourceFileAsString("validMigrationNoCaseAttachments.json");
         migrationMessageValidator.validate(validMessage, messageId);
     }
+
+    @Test
+    public void shouldValidateWithOptionalFieldsNull() throws Exception {
+        var validMessage = getResourceFileAsString("validMigrationWithOptionalFieldsNull.json");
+        migrationMessageValidator.validate(validMessage, messageId);
+    }
 }

--- a/src/test/java/uk/gov/digital/ho/hocs/queue/migration/MigrationServiceTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/queue/migration/MigrationServiceTest.java
@@ -1,9 +1,7 @@
 package uk.gov.digital.ho.hocs.queue.migration;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.jayway.jsonpath.PathNotFoundException;
-import net.minidev.json.JSONArray;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -17,13 +15,9 @@ import uk.gov.digital.ho.hocs.client.migration.casework.dto.CreateMigrationCaseR
 import uk.gov.digital.ho.hocs.client.document.DocumentS3Client;
 import uk.gov.digital.ho.hocs.client.migration.casework.dto.MigrationComplaintCorrespondent;
 import uk.gov.digital.ho.hocs.client.workflow.WorkflowClient;
-import uk.gov.digital.ho.hocs.client.workflow.dto.DocumentSummary;
 import uk.gov.digital.ho.hocs.queue.complaints.CorrespondentType;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
+import java.util.*;
 
 import static org.junit.Assert.*;
 import static org.mockito.ArgumentMatchers.any;
@@ -54,7 +48,7 @@ public class MigrationServiceTest {
 
     private MigrationCaseTypeData migrationCaseTypeData;
 
-    private DocumentSummary documentSummary;
+    private List<CaseAttachment> caseAttachment;
 
     private ObjectMapper objectMapper;
 
@@ -73,14 +67,18 @@ public class MigrationServiceTest {
         List<MigrationComplaintCorrespondent> additionalCorrespondents = migrationService.getAdditionalCorrespondents(
                 migrationData.getAdditionalCorrespondents());
 
+        caseAttachment = new ArrayList<>();
+        caseAttachment.add(new CaseAttachment("document1.pdf","To document","e7f5d229-3f23-450c-8f11-8ef647943ae3"));
+        caseAttachment.add(new CaseAttachment("document2.pdf","pdf","9bf2665f-6b21-47af-8789-34a25b136670"));
 
-        documentSummary = new DocumentSummary("migration","","");
-        createMigrationCaseRequest = new CreateMigrationCaseRequest(migrationData.getComplaintType(),
-                migrationData.getDateReceived(), List.of(documentSummary),
+        createMigrationCaseRequest = new CreateMigrationCaseRequest(
+                migrationData.getComplaintType(),
+                migrationData.getDateReceived(),
                 initialData,
                 "MIGRATION",
                 primaryCorrespondent,
-                additionalCorrespondents);
+                additionalCorrespondents,
+                caseAttachment);
         caseworkCaseResponse = new CreateCaseworkCaseResponse();
         when(migrationCaseworkClient.migrateCase(any(CreateMigrationCaseRequest.class))).thenReturn(caseworkCaseResponse);
     }
@@ -146,6 +144,25 @@ public class MigrationServiceTest {
         assertTrue(additionalCorrespondentsJson.isEmpty());
     }
 
+    @Test
+    public void shouldContainCaseAttachments() {
+        List<CaseAttachment> caseAttachments = createMigrationCaseRequest.getAttachments();
+
+        List<CaseAttachment> expectedAttachments = Arrays.asList(
+                new CaseAttachment(
+                        "document1.pdf",
+                        "To document",
+                        "e7f5d229-3f23-450c-8f11-8ef647943ae3"
+                ),
+                new CaseAttachment(
+                        "document2.pdf",
+                        "pdf",
+                        "9bf2665f-6b21-47af-8789-34a25b136670"
+                ));
+
+        assertEquals(expectedAttachments, caseAttachments);
+    }
+
     private MigrationComplaintCorrespondent createCorrespondent() {
         return new MigrationComplaintCorrespondent(
                 "fullName",
@@ -161,4 +178,6 @@ public class MigrationServiceTest {
                 "reference"
         );
     }
+
+
 }

--- a/src/test/java/uk/gov/digital/ho/hocs/queue/migration/MigrationServiceTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/queue/migration/MigrationServiceTest.java
@@ -138,10 +138,11 @@ public class MigrationServiceTest {
         migrationCaseTypeData = new MigrationCaseTypeData();
         migrationService = new MigrationService(workflowClient, migrationCaseworkClient, clientContext, documentS3Client, objectMapper);
 
-        Optional<String> additionalCorrespondentsJson =
-               migrationData.getAdditionalCorrespondents();
+        List<MigrationComplaintCorrespondent> migrationComplaintCorrespondents =
+                migrationService.getAdditionalCorrespondents(
+                        migrationData.getAdditionalCorrespondents());
 
-        assertTrue(additionalCorrespondentsJson.isEmpty());
+        assertTrue(migrationComplaintCorrespondents.isEmpty());
     }
 
     @Test
@@ -161,6 +162,19 @@ public class MigrationServiceTest {
                 ));
 
         assertEquals(expectedAttachments, caseAttachments);
+    }
+
+    @Test
+    public void shouldNotContainAttachments() {
+        json = getResourceFileAsString("validMigrationNoCaseAttachments.json");
+        migrationData = new MigrationData(json);
+        migrationCaseTypeData = new MigrationCaseTypeData();
+        migrationService = new MigrationService(workflowClient, migrationCaseworkClient, clientContext, documentS3Client, objectMapper);
+
+        List<CaseAttachment> caseAttachments =
+                migrationService.getCaseAttachments(
+                        migrationData.getCaseAttachments());
+        assertTrue(caseAttachments.isEmpty());
     }
 
     private MigrationComplaintCorrespondent createCorrespondent() {

--- a/src/test/resources/invalidMigrationMessageMissingCaseAttachments.json
+++ b/src/test/resources/invalidMigrationMessageMissingCaseAttachments.json
@@ -48,17 +48,5 @@
   "caseData": [
     {"name": "type", "value": "cms"},
     {"name": "creationDate", "value": "01/07/2022"}
-  ],
-  "caseAttachments": [
-    {
-      "documentPath": "e7f5d229-3f23-450c-8f11-8ef647943ae3",
-      "displayName": "document1.pdf",
-      "documentType": "To document"
-    },
-    {
-      "documentPath": "9bf2665f-6b21-47af-8789-34a25b136670",
-      "displayName": "document2.pdf",
-      "documentType": "pdf"
-    }
   ]
 }

--- a/src/test/resources/validMigrationNoAdditionalCorrespondents.json
+++ b/src/test/resources/validMigrationNoAdditionalCorrespondents.json
@@ -23,8 +23,8 @@
   ],
   "caseAttachments": [
     {
-      "path": "path",
-      "label": "label",
+      "documentPath": "path",
+      "displayName": "label",
       "documentType": "documentType"
     }
   ]

--- a/src/test/resources/validMigrationNoCaseAttachments.json
+++ b/src/test/resources/validMigrationNoCaseAttachments.json
@@ -49,16 +49,5 @@
     {"name": "type", "value": "cms"},
     {"name": "creationDate", "value": "01/07/2022"}
   ],
-  "caseAttachments": [
-    {
-      "documentPath": "e7f5d229-3f23-450c-8f11-8ef647943ae3",
-      "displayName": "document1.pdf",
-      "documentType": "To document"
-    },
-    {
-      "documentPath": "9bf2665f-6b21-47af-8789-34a25b136670",
-      "displayName": "document2.pdf",
-      "documentType": "pdf"
-    }
-  ]
+  "caseAttachments": []
 }

--- a/src/test/resources/validMigrationWithCaseAttachments.json
+++ b/src/test/resources/validMigrationWithCaseAttachments.json
@@ -1,0 +1,59 @@
+{
+  "caseType": "COMP",
+  "sourceCaseId": "in",
+  "primaryCorrespondent": {
+    "fullName": "fullName",
+    "correspondentType": "COMPLAINANT",
+    "address1": "address1",
+    "address2": "address2",
+    "address3": "address3",
+    "postcode": "postcode",
+    "country": "country",
+    "organisation": "organisation",
+    "telephone": "telephone",
+    "email": "email",
+    "reference": "reference"
+  },
+  "additionalCorrespondents": [
+    {
+      "fullName": "fullName",
+      "correspondentType": "COMPLAINANT",
+      "address1": "address1",
+      "address2": "address2",
+      "address3": "address3",
+      "postcode": "postcode",
+      "country": "country",
+      "organisation": "organisation",
+      "telephone": "telephone",
+      "email": "email",
+      "reference": "reference"
+    },
+    {
+      "fullName": "fullName",
+      "correspondentType": "COMPLAINANT",
+      "address1": "address1",
+      "address2": "address2",
+      "address3": "address3",
+      "postcode": "postcode",
+      "country": "country",
+      "organisation": "organisation",
+      "telephone": "telephone",
+      "email": "email",
+      "reference": "reference"
+    }
+  ],
+  "caseStatus": "caseStatus",
+  "caseStatusDate": "1947-02-14",
+  "creationDate": "1965-06-22",
+  "caseData": [
+    {"name": "type", "value": "cms"},
+    {"name": "creationDate", "value": "01/07/2022"}
+  ],
+  "caseAttachments": [
+    {
+      "documentPath": "75c08911-92e8-44ac-845a-59c56daa7de9",
+      "displayName": "standard-tube-map.pdf",
+      "documentType": "To document"
+    }
+  ]
+}

--- a/src/test/resources/validMigrationWithOptionalFieldsNull.json
+++ b/src/test/resources/validMigrationWithOptionalFieldsNull.json
@@ -1,0 +1,46 @@
+{
+  "caseType": "COMP",
+  "sourceCaseId": "in",
+  "primaryCorrespondent": {
+    "fullName": "fullName",
+    "correspondentType": "COMPLAINANT",
+    "address1": null,
+    "address2": null,
+    "address3": null,
+    "postcode": null,
+    "country": null,
+    "organisation": null,
+    "telephone": null,
+    "email": null,
+    "reference": null
+  },
+  "additionalCorrespondents": [
+    {
+      "fullName": "fullName",
+      "correspondentType": "COMPLAINANT",
+      "address1": null,
+      "address2": null,
+      "address3": null,
+      "postcode": null,
+      "country": null,
+      "organisation": null,
+      "telephone": null,
+      "email": null,
+      "reference": null
+    }
+  ],
+  "caseStatus": "caseStatus",
+  "caseStatusDate": "1947-02-14",
+  "creationDate": "1965-06-22",
+  "caseData": [
+    {"name": "type", "value": "cms"},
+    {"name": "creationDate", "value": "01/07/2022"}
+  ],
+  "caseAttachments": [
+    {
+      "documentPath": "e7f5d229-3f23-450c-8f11-8ef647943ae3",
+      "displayName": "document1.pdf",
+      "documentType": "To document"
+    }
+  ]
+}


### PR DESCRIPTION
Extract case attachments and add to request to casework.

Validation requires mandatory (non-null) fields for a case attachment:
- displayName
- documentPath
- documentType

Test for valid and invalid scenarios; both validation and deserialisation.
Using hocs-migration-schema 0.10.0
