### PR TITLE
HOCS-6257: change identity properties

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -21,7 +21,7 @@ steps:
     image: quay.io/ukhomeofficedigital/hocs-helm-kubectl:1.1.0
     environment:
       CHART_NAME: hocs-case-creator
-      CHART_VERSION: ^5.0.0
+      CHART_VERSION: ^6.0.0
       KUBE_CLUSTER: acp-notprod
       KUBE_NAMESPACE: cs-dev
       KUBE_SERVER: https://kube-api-notprod.notprod.acp.homeoffice.gov.uk
@@ -37,7 +37,7 @@ steps:
     name: migrator-cs-dev
     environment:
       CHART_NAME: hocs-case-migrator
-      CHART_VERSION: ^6.0.0
+      CHART_VERSION: ^7.0.0
     commands:
       - ./ci/helm/helm-chart-deploy.sh --values ./helm/hocs-case-migrator.yaml
     depends_on:

--- a/src/main/java/uk/gov/digital/ho/hocs/queue/complaints/ukvi/UKVIComplaintService.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/queue/complaints/ukvi/UKVIComplaintService.java
@@ -28,9 +28,9 @@ public class UKVIComplaintService {
                                 ComplaintService complaintService,
                                 ClientContext clientContext,
                                 UKVITypeData ukviTypeData,
-                                @Value("${case.creator.identities.complaints.ukvi.user}") String user,
-                                @Value("${case.creator.identities.complaints.ukvi.group}") String group,
-                                @Value("${case.creator.identities.complaints.ukvi.team}") String team) {
+                                @Value("${case.creator.identity.user}") String user,
+                                @Value("${case.creator.identity.group}") String group,
+                                @Value("${case.creator.identity.team}") String team) {
         this.objectMapper = objectMapper;
         this.enumMappingsRepository = enumMappingsRepository;
         this.complaintService = complaintService;

--- a/src/main/java/uk/gov/digital/ho/hocs/queue/migration/MigrationCaseService.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/queue/migration/MigrationCaseService.java
@@ -19,9 +19,9 @@ public class MigrationCaseService {
     public MigrationCaseService(MigrationService migrationService,
                                 ClientContext clientContext,
                                 MigrationCaseTypeData migrationCaseTypeData,
-                                @Value("${case.creator.identities.migration.user}") String user,
-                                @Value("${case.creator.identities.migration.group}") String group,
-                                @Value("${case.creator.identities.migration.team}") String team) {
+                                @Value("${case.creator.identity.user}") String user,
+                                @Value("${case.creator.identity.group}") String group,
+                                @Value("${case.creator.identity.team}") String team) {
         this.migrationService = migrationService;
         this.clientContext = clientContext;
         this.migrationCaseTypeData = migrationCaseTypeData;

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -28,17 +28,11 @@ aws:
         bucket-kms-key:
       bucket-name: untrusted-bucket
 
-  case:
-    creator:
-      case-service: http://localhost:8082
-      identities:
-        complaints:
-          ukvi:
-            group:
-            team:
-            user:
-        migration:
-          group:
-          team:
-          user:
-      workflow-service: http://localhost:8091
+case:
+  creator:
+    case-service: http://localhost:8082
+    workflow-service: http://localhost:8091
+    identity:
+      group:
+      team:
+      user:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -46,17 +46,11 @@ aws:
 case:
   creator:
     case-service: http://localhost:8082
-    identities:
-      complaints:
-        ukvi:
-          group:
-          team:
-          user:
-      migration:
-        group:
-        team:
-        user:
     workflow-service: http://localhost:8091
+    identity:
+      group:
+      team:
+      user:
 
 management:
   endpoints:


### PR DESCRIPTION
As this service is deployed and driven from deployment configuration,
there is no longer a need to have two different set of identities within
the dataset.

This change pulls both of the current sets into one common one.

--- 
This is built on top of #206 to save headaches with merge conflicts and rebasing.