### PR TITLE
HOCS-6249: change client context use

### DIFF
--- a/src/main/java/uk/gov/digital/ho/hocs/application/aspects/QueueListenerContextAspect.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/application/aspects/QueueListenerContextAspect.java
@@ -1,0 +1,42 @@
+package uk.gov.digital.ho.hocs.application.aspects;
+
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Pointcut;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import uk.gov.digital.ho.hocs.application.ClientContext;
+
+@Component
+@Aspect
+public class QueueListenerContextAspect {
+
+    private final ClientContext clientContext;
+    private final String user;
+    private final String group;
+    private final String team;
+
+    public QueueListenerContextAspect(ClientContext clientContext,
+                               @Value("${case.creator.identity.user}") String user,
+                               @Value("${case.creator.identity.group}") String group,
+                               @Value("${case.creator.identity.team}") String team) {
+        this.clientContext = clientContext;
+        this.user = user;
+        this.group = group;
+        this.team = team;
+    }
+
+    @Pointcut("execution(* uk.gov.digital.ho.hocs.queue.common.QueueListener.onMessageReceived(..))")
+    public void messageReceivedPointcut(){
+    }
+
+    @Around("messageReceivedPointcut()")
+    public void aroundAdvice(ProceedingJoinPoint joinPoint) throws Throwable {
+        var getArguments = joinPoint.getArgs();
+        var messageId = (String) getArguments[1];
+        clientContext.setContext(user, group, team, messageId);
+        joinPoint.proceed();
+    }
+
+}

--- a/src/main/java/uk/gov/digital/ho/hocs/queue/common/MigrationQueueListener.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/queue/common/MigrationQueueListener.java
@@ -18,7 +18,7 @@ import java.util.UUID;
 @Service
 @Slf4j
 @Profile("migration")
-public class MigrationQueueListener {
+public class MigrationQueueListener implements QueueListener {
 
     private final MessageHandler messageHandler;
 
@@ -35,7 +35,7 @@ public class MigrationQueueListener {
     }
 
     @SqsListener(value = "${aws.sqs.case-migrator.url}", deletionPolicy = SqsMessageDeletionPolicy.NO_REDRIVE)
-    public void onMigrationEvent(String message,
+    public void onMessageReceived(String message,
                                  @Header("MessageId") String messageId,
                                  @Header(value = "MessageType", required = false) MessageType messageType,
                                  @Header(value = "ExternalReference", required = false) UUID externalReference) throws Exception {

--- a/src/main/java/uk/gov/digital/ho/hocs/queue/common/QueueListener.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/queue/common/QueueListener.java
@@ -1,0 +1,12 @@
+package uk.gov.digital.ho.hocs.queue.common;
+
+import org.springframework.messaging.handler.annotation.Header;
+
+import java.util.UUID;
+
+public interface QueueListener {
+    void onMessageReceived(String message,
+                           @Header("MessageId") String messageId,
+                           @Header(value = "MessageType", required = false) MessageType messageType,
+                           @Header(value = "ExternalReference", required = false) UUID externalReference) throws Exception;
+}

--- a/src/main/java/uk/gov/digital/ho/hocs/queue/common/UkviQueueListener.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/queue/common/UkviQueueListener.java
@@ -18,7 +18,7 @@ import java.util.UUID;
 @Service
 @Slf4j
 @Profile("ukvi")
-public class UkviQueueListener {
+public class UkviQueueListener implements QueueListener {
 
     private final MessageHandler messageHandler;
 
@@ -35,7 +35,7 @@ public class UkviQueueListener {
     }
 
     @SqsListener(value = "${aws.sqs.case-creator.url}", deletionPolicy = SqsMessageDeletionPolicy.ON_SUCCESS)
-    public void onComplaintEvent(String message,
+    public void onMessageReceived(String message,
                                  @Header("MessageId") String messageId,
                                  @Header(value = "MessageType", required = false) MessageType messageType,
                                  @Header(value = "ExternalReference", required = false) UUID externalReference) throws Exception {

--- a/src/main/java/uk/gov/digital/ho/hocs/queue/complaints/ukvi/UKVIComplaintMessageHandler.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/queue/complaints/ukvi/UKVIComplaintMessageHandler.java
@@ -21,7 +21,7 @@ public class UKVIComplaintMessageHandler implements MessageHandler {
     @Override
     public void handleMessage(String messageId, String message) throws Exception {
         ukviComplaintValidator.validate(messageId, message);
-        ukviComplaintService.createComplaint(messageId, message);
+        ukviComplaintService.createComplaint(message);
     }
 
     @Override

--- a/src/main/java/uk/gov/digital/ho/hocs/queue/complaints/ukvi/UKVIComplaintService.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/queue/complaints/ukvi/UKVIComplaintService.java
@@ -3,9 +3,7 @@ package uk.gov.digital.ho.hocs.queue.complaints.ukvi;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
-import uk.gov.digital.ho.hocs.application.ClientContext;
 import uk.gov.digital.ho.hocs.domain.repositories.EnumMappingsRepository;
 import uk.gov.digital.ho.hocs.queue.complaints.ComplaintService;
 
@@ -16,33 +14,20 @@ public class UKVIComplaintService {
     private final ObjectMapper objectMapper;
     private final EnumMappingsRepository enumMappingsRepository;
     private final ComplaintService complaintService;
-    private final ClientContext clientContext;
     private final UKVITypeData ukviTypeData;
-    private final String user;
-    private final String group;
-    private final String team;
 
     @Autowired
     public UKVIComplaintService(ObjectMapper objectMapper,
                                 EnumMappingsRepository enumMappingsRepository,
                                 ComplaintService complaintService,
-                                ClientContext clientContext,
-                                UKVITypeData ukviTypeData,
-                                @Value("${case.creator.identity.user}") String user,
-                                @Value("${case.creator.identity.group}") String group,
-                                @Value("${case.creator.identity.team}") String team) {
+                                UKVITypeData ukviTypeData) {
         this.objectMapper = objectMapper;
         this.enumMappingsRepository = enumMappingsRepository;
         this.complaintService = complaintService;
-        this.clientContext = clientContext;
         this.ukviTypeData = ukviTypeData;
-        this.user = user;
-        this.group = group;
-        this.team = team;
     }
 
-    public void createComplaint(String messageId, String jsonBody) {
-        clientContext.setContext(user, group, team, messageId);
+    public void createComplaint(String jsonBody) {
         complaintService.createComplaint(new UKVIComplaintData(jsonBody, objectMapper, enumMappingsRepository), ukviTypeData);
     }
 }

--- a/src/main/java/uk/gov/digital/ho/hocs/queue/migration/MigrationCaseService.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/queue/migration/MigrationCaseService.java
@@ -1,37 +1,22 @@
 package uk.gov.digital.ho.hocs.queue.migration;
 
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
-import uk.gov.digital.ho.hocs.application.ClientContext;
 
 @Slf4j
 @Service
 public class MigrationCaseService {
 
     private final MigrationService migrationService;
-    private final ClientContext clientContext;
     private final MigrationCaseTypeData migrationCaseTypeData;
-    private final String user;
-    private final String group;
-    private final String team;
 
     public MigrationCaseService(MigrationService migrationService,
-                                ClientContext clientContext,
-                                MigrationCaseTypeData migrationCaseTypeData,
-                                @Value("${case.creator.identity.user}") String user,
-                                @Value("${case.creator.identity.group}") String group,
-                                @Value("${case.creator.identity.team}") String team) {
+                                MigrationCaseTypeData migrationCaseTypeData) {
         this.migrationService = migrationService;
-        this.clientContext = clientContext;
         this.migrationCaseTypeData = migrationCaseTypeData;
-        this.user = user;
-        this.group = group;
-        this.team = team;
     }
 
-    public void createMigrationCase(String messageId, String jsonBody) {
-        clientContext.setContext(user, group, team, messageId);
+    public void createMigrationCase(String jsonBody) {
         MigrationData migrationData = new MigrationData(jsonBody);
         migrationCaseTypeData.setCaseType(migrationData.getComplaintType());
         migrationService.createMigrationCase(migrationData, migrationCaseTypeData);

--- a/src/main/java/uk/gov/digital/ho/hocs/queue/migration/MigrationMessageHandler.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/queue/migration/MigrationMessageHandler.java
@@ -26,7 +26,7 @@ public class MigrationMessageHandler implements MessageHandler {
     public void handleMessage(String messageId, String message) throws Exception {
         log.info("Received new message MessageId : {}", messageId);
         migrationValidator.validate(messageId, message);
-        migrationCaseService.createMigrationCase(messageId, message);
+        migrationCaseService.createMigrationCase(message);
     }
 
     @Override

--- a/src/test/java/uk/gov/digital/ho/hocs/queue/common/MigrationQueueListenerTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/queue/common/MigrationQueueListenerTest.java
@@ -42,23 +42,23 @@ public class MigrationQueueListenerTest {
     public void messageTypeMatches_callHandler() throws Exception {
         when(migrationMessageHandler.getMessageType()).thenCallRealMethod();
 
-        migrationQueueListener.onMigrationEvent("test", "test", MessageType.MIGRATION, UUID.randomUUID());
+        migrationQueueListener.onMessageReceived("test", "test", MessageType.MIGRATION, UUID.randomUUID());
 
         verify(messageLogService).createMessageLogEntry(eq("test"), any(UUID.class), eq("test"));
         verify(migrationMessageHandler).getMessageType();
         verify(migrationMessageHandler).handleMessage("test", "test");
-        verify(messageLogService).completeMessageLogEntry(eq("test"));
+        verify(messageLogService).completeMessageLogEntry("test");
         verifyNoMoreInteractions(migrationMessageHandler);
     }
 
     @Test
     public void messageTypeNull_callHandler() throws Exception {
-        migrationQueueListener.onMigrationEvent("test", "test", null, UUID.randomUUID());
+        migrationQueueListener.onMessageReceived("test", "test", null, UUID.randomUUID());
 
         verify(messageLogService).createMessageLogEntry(eq("test"), any(UUID.class), eq("test"));
         verify(migrationMessageHandler, times(0)).getMessageType();
         verify(migrationMessageHandler).handleMessage("test", "test");
-        verify(messageLogService).completeMessageLogEntry(eq("test"));
+        verify(messageLogService).completeMessageLogEntry("test");
         verifyNoMoreInteractions(migrationMessageHandler);
     }
 
@@ -66,11 +66,11 @@ public class MigrationQueueListenerTest {
     public void messageTypeNotMatch_callHandler() throws Exception {
         when(migrationMessageHandler.getMessageType()).thenCallRealMethod();
 
-        migrationQueueListener.onMigrationEvent("test", "test", MessageType.UKVI_COMPLAINTS, UUID.randomUUID());
+        migrationQueueListener.onMessageReceived("test", "test", MessageType.UKVI_COMPLAINTS, UUID.randomUUID());
 
         verify(messageLogService).createMessageLogEntry(eq("test"), any(UUID.class), eq("test"));
         verify(migrationMessageHandler).getMessageType();
-        verify(messageLogService).updateMessageLogEntryStatus(eq("test"), eq(Status.MESSAGE_TYPE_INVALID));
+        verify(messageLogService).updateMessageLogEntryStatus("test", Status.MESSAGE_TYPE_INVALID);
         verifyNoMoreInteractions(migrationMessageHandler);
     }
 
@@ -81,7 +81,7 @@ public class MigrationQueueListenerTest {
 
         when(migrationMessageHandler.getMessageType()).thenReturn(MessageType.MIGRATION);
 
-        migrationQueueListener.onMigrationEvent("test", "test", null, null);
+        migrationQueueListener.onMessageReceived("test", "test", null, null);
 
         verifyNoMoreInteractions(migrationMessageHandler);
     }

--- a/src/test/java/uk/gov/digital/ho/hocs/queue/common/UkviQueueListenerTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/queue/common/UkviQueueListenerTest.java
@@ -42,23 +42,23 @@ public class UkviQueueListenerTest {
     public void messageTypeMatches_callHandler() throws Exception {
         when(ukviComplaintMessageHandler.getMessageType()).thenCallRealMethod();
 
-        ukviQueueListener.onComplaintEvent("test", "test", MessageType.UKVI_COMPLAINTS, UUID.randomUUID());
+        ukviQueueListener.onMessageReceived("test", "test", MessageType.UKVI_COMPLAINTS, UUID.randomUUID());
 
         verify(messageLogService).createMessageLogEntry(eq("test"), any(UUID.class), eq("test"));
         verify(ukviComplaintMessageHandler).getMessageType();
         verify(ukviComplaintMessageHandler).handleMessage("test", "test");
-        verify(messageLogService).completeMessageLogEntry(eq("test"));
+        verify(messageLogService).completeMessageLogEntry("test");
         verifyNoMoreInteractions(ukviComplaintMessageHandler);
     }
 
     @Test
     public void messageTypeNull_callHandler() throws Exception {
-        ukviQueueListener.onComplaintEvent("test", "test", null, UUID.randomUUID());
+        ukviQueueListener.onMessageReceived("test", "test", null, UUID.randomUUID());
 
         verify(messageLogService).createMessageLogEntry(eq("test"), any(UUID.class), eq("test"));
         verify(ukviComplaintMessageHandler, times(0)).getMessageType();
         verify(ukviComplaintMessageHandler).handleMessage("test", "test");
-        verify(messageLogService).completeMessageLogEntry(eq("test"));
+        verify(messageLogService).completeMessageLogEntry("test");
         verifyNoMoreInteractions(ukviComplaintMessageHandler);
     }
 
@@ -66,11 +66,11 @@ public class UkviQueueListenerTest {
     public void messageTypeNotMatch_callHandler() throws Exception {
         when(ukviComplaintMessageHandler.getMessageType()).thenCallRealMethod();
 
-        ukviQueueListener.onComplaintEvent("test", "test", MessageType.MIGRATION, UUID.randomUUID());
+        ukviQueueListener.onMessageReceived("test", "test", MessageType.MIGRATION, UUID.randomUUID());
 
         verify(messageLogService).createMessageLogEntry(eq("test"), any(UUID.class), eq("test"));
         verify(ukviComplaintMessageHandler).getMessageType();
-        verify(messageLogService).updateMessageLogEntryStatus(eq("test"), eq(Status.MESSAGE_TYPE_INVALID));
+        verify(messageLogService).updateMessageLogEntryStatus("test", Status.MESSAGE_TYPE_INVALID);
         verifyNoMoreInteractions(ukviComplaintMessageHandler);
     }
 
@@ -81,7 +81,7 @@ public class UkviQueueListenerTest {
 
         when(ukviComplaintMessageHandler.getMessageType()).thenReturn(MessageType.MIGRATION);
 
-        ukviQueueListener.onComplaintEvent("test", "test", null, null);
+        ukviQueueListener.onMessageReceived("test", "test", null, null);
 
         verifyNoMoreInteractions(ukviComplaintMessageHandler);
     }

--- a/src/test/java/uk/gov/digital/ho/hocs/queue/complaints/ukvi/UKVIComplaintServiceTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/queue/complaints/ukvi/UKVIComplaintServiceTest.java
@@ -5,7 +5,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
-import uk.gov.digital.ho.hocs.application.ClientContext;
 import uk.gov.digital.ho.hocs.domain.repositories.EnumMappingsRepository;
 import uk.gov.digital.ho.hocs.queue.complaints.ComplaintService;
 
@@ -20,8 +19,6 @@ public class UKVIComplaintServiceTest {
     @Mock
     ComplaintService complaintService;
     @Mock
-    ClientContext clientContext;
-    @Mock
     ObjectMapper objectMapper;
     @Mock
     EnumMappingsRepository enumMappingsRepository;
@@ -29,10 +26,10 @@ public class UKVIComplaintServiceTest {
     @Test
     public void shouldCreateComplaint() {
         UKVITypeData complaintTypeData = new UKVITypeData();
-        UKVIComplaintService ukviComplaintService = new UKVIComplaintService(objectMapper, enumMappingsRepository, complaintService, clientContext, complaintTypeData, "user", "group", "team");
+        UKVIComplaintService ukviComplaintService = new UKVIComplaintService(objectMapper, enumMappingsRepository, complaintService, complaintTypeData);
         String json = getResourceFileAsString("staffBehaviour.json");
 
-        ukviComplaintService.createComplaint("messageId", json);
+        ukviComplaintService.createComplaint(json);
 
         verify(complaintService).createComplaint(any(UKVIComplaintData.class), eq(complaintTypeData));
     }
@@ -40,10 +37,10 @@ public class UKVIComplaintServiceTest {
     @Test
     public void shouldCreateComplaintWithNoCorrespondent() {
         UKVITypeData complaintTypeData = new UKVITypeData();
-        UKVIComplaintService ukviComplaintService = new UKVIComplaintService(objectMapper, enumMappingsRepository, complaintService, clientContext, complaintTypeData, "user", "group", "team");
+        UKVIComplaintService ukviComplaintService = new UKVIComplaintService(objectMapper, enumMappingsRepository, complaintService, complaintTypeData);
         String json = getResourceFileAsString("existingNoCorrespondent.json");
 
-        ukviComplaintService.createComplaint("messageId", json);
+        ukviComplaintService.createComplaint(json);
 
         verify(complaintService).createComplaint(any(UKVIComplaintData.class), eq(complaintTypeData));
     }


### PR DESCRIPTION
When setting the client context the previous solution only did this at the message service level manually.

There are several issues with this approach:
- Log lines that predate this do not have the associated correlation id.
- This should be an automated concern for logging purposes, and not manually triggered.

This change pulls the ClientContext handling into an AOP that injects on every invocation of the new QueueListener onMessageReceived method.