### PR TITLE
HOCS-6249: reorder ignoring messages

### DIFF
--- a/src/main/java/uk/gov/digital/ho/hocs/domain/service/MessageLogService.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/domain/service/MessageLogService.java
@@ -24,6 +24,12 @@ public class MessageLogService {
         messageLogRepository.save(messageLog);
     }
 
+    public void createMessageLogEntry(String messageId, UUID externalReference, String message, Status status) {
+        var messageLog =
+                new MessageLog(messageId, externalReference, null, message, status, null, LocalDateTime.now());
+        messageLogRepository.save(messageLog);
+    }
+
     @Transactional
     public void updateMessageLogEntryCaseUuidAndStatus(String messageId, UUID caseUuid, Status status) {
         messageLogRepository.updateCaseUuidAndStatus(messageId, caseUuid, status);
@@ -38,5 +44,6 @@ public class MessageLogService {
     public void completeMessageLogEntry(String messageId) {
         messageLogRepository.updateStatusAndCompleted(messageId, Status.COMPLETED);
     }
+
 
 }

--- a/src/main/java/uk/gov/digital/ho/hocs/entrypoint/MigrationQueueListener.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/entrypoint/MigrationQueueListener.java
@@ -38,17 +38,17 @@ public class MigrationQueueListener implements QueueListener {
 
     @SqsListener(value = "${aws.sqs.case-migrator.url}", deletionPolicy = SqsMessageDeletionPolicy.NO_REDRIVE)
     public void onMessageReceived(String message,
-                                 @Header("MessageId") String messageId,
-                                 @Header(value = "MessageType", required = false) MessageType messageType,
-                                 @Header(value = "ExternalReference", required = false) UUID externalReference) throws Exception {
-        // Create message log entry
-        messageLogService.createMessageLogEntry(messageId, externalReference, message);
-
+                                  @Header("MessageId") String messageId,
+                                  @Header(value = "MessageType", required = false) MessageType messageType,
+                                  @Header(value = "ExternalReference", required = false) UUID externalReference) throws Exception {
         if (shouldIgnoreMessages) {
             log.warn("Message flagged to ignore: {}", messageId);
-            messageLogService.updateMessageLogEntryStatus(messageId, Status.IGNORED);
+            messageLogService.createMessageLogEntry(messageId, externalReference, message, Status.IGNORED);
             return;
         }
+
+        // Create message log entry
+        messageLogService.createMessageLogEntry(messageId, externalReference, message);
 
         if (messageType == null ||
                 messageHandler.getMessageType().equals(messageType)) {

--- a/src/main/java/uk/gov/digital/ho/hocs/entrypoint/UkviQueueListener.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/entrypoint/UkviQueueListener.java
@@ -38,17 +38,16 @@ public class UkviQueueListener implements QueueListener {
 
     @SqsListener(value = "${aws.sqs.case-creator.url}", deletionPolicy = SqsMessageDeletionPolicy.ON_SUCCESS)
     public void onMessageReceived(String message,
-                                 @Header("MessageId") String messageId,
-                                 @Header(value = "MessageType", required = false) MessageType messageType,
-                                 @Header(value = "ExternalReference", required = false) UUID externalReference) throws Exception {
-        // Create message log entry
-        messageLogService.createMessageLogEntry(messageId, externalReference, message);
-
+                                  @Header("MessageId") String messageId,
+                                  @Header(value = "MessageType", required = false) MessageType messageType,
+                                  @Header(value = "ExternalReference", required = false) UUID externalReference) throws Exception {
         if (shouldIgnoreMessages) {
             log.warn("Message flagged to ignore: {}", messageId);
-            messageLogService.updateMessageLogEntryStatus(messageId, Status.IGNORED);
+            messageLogService.createMessageLogEntry(messageId, externalReference, message, Status.IGNORED);
             return;
         }
+
+        messageLogService.createMessageLogEntry(messageId, externalReference, message);
 
         if (messageType == null ||
                 messageHandler.getMessageType().equals(messageType)) {


### PR DESCRIPTION
Instead of doing 2 database transactions for ignored messages, this
change reorders the listeners to first do a check and if a message is
marked to ignore then create a message log in one transaction with the
correct Status.