### PR TITLE
HOCS-6402: fix MessageLog repository method

### DIFF
--- a/src/main/java/uk/gov/digital/ho/hocs/domain/repositories/MessageLogRepository.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/domain/repositories/MessageLogRepository.java
@@ -37,13 +37,12 @@ public interface MessageLogRepository extends CrudRepository<MessageLog, String>
                              @Param("processingDateTime") LocalDateTime processingDateTime
     );
 
+    long countByStatusAndReceivedBetween(Status status, LocalDateTime from, LocalDateTime to);
 
-    long countByStatusAndCompletedBetween(Status status, LocalDateTime from, LocalDateTime to);
+    long countByStatusAndReceivedBefore(Status status, LocalDateTime to);
 
-    long countByStatusAndCompletedBefore(Status status, LocalDateTime to);
+    Stream<MessageLog> findByStatusAndReceivedBetween(Status status, LocalDateTime from, LocalDateTime to);
 
-    Stream<MessageLog> findByStatusAndCompletedBetween(Status status, LocalDateTime from, LocalDateTime to);
-
-    Stream<MessageLog> findByStatusAndCompletedBefore(Status status, LocalDateTime to);
+    Stream<MessageLog> findByStatusAndReceivedBefore(Status status, LocalDateTime to);
 
 }

--- a/src/main/java/uk/gov/digital/ho/hocs/domain/service/MessageLogService.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/domain/service/MessageLogService.java
@@ -56,17 +56,17 @@ public class MessageLogService {
     @Transactional(readOnly = true)
     public long getCountOfPendingMessagesBetweenDates(LocalDateTime from, @NotNull LocalDateTime to) {
         if (from == null) {
-            return messageLogRepository.countByStatusAndCompletedBefore(Status.PENDING, to);
+            return messageLogRepository.countByStatusAndReceivedBefore(Status.PENDING, to);
         }
-        return messageLogRepository.countByStatusAndCompletedBetween(Status.PENDING, from, to);
+        return messageLogRepository.countByStatusAndReceivedBetween(Status.PENDING, from, to);
     }
 
     @Transactional(readOnly = true)
     public Stream<MessageLog> getPendingMessagesBetweenDates(LocalDateTime from, @NotNull LocalDateTime to) {
         if (from == null) {
-            return messageLogRepository.findByStatusAndCompletedBefore(Status.PENDING, to);
+            return messageLogRepository.findByStatusAndReceivedBefore(Status.PENDING, to);
         }
-        return messageLogRepository.findByStatusAndCompletedBetween(Status.PENDING, from, to);
+        return messageLogRepository.findByStatusAndReceivedBetween(Status.PENDING, from, to);
     }
 
 }

--- a/src/main/java/uk/gov/digital/ho/hocs/domain/service/MessageLogService.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/domain/service/MessageLogService.java
@@ -2,6 +2,7 @@ package uk.gov.digital.ho.hocs.domain.service;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import uk.gov.digital.ho.hocs.domain.model.Message;
 import uk.gov.digital.ho.hocs.domain.queue.common.MessageType;
 import uk.gov.digital.ho.hocs.domain.repositories.MessageLogRepository;
 import uk.gov.digital.ho.hocs.domain.repositories.entities.MessageLog;
@@ -9,8 +10,8 @@ import uk.gov.digital.ho.hocs.domain.repositories.entities.Status;
 
 import javax.validation.constraints.NotNull;
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.UUID;
-import java.util.stream.Stream;
 
 @Service
 public class MessageLogService {
@@ -62,11 +63,12 @@ public class MessageLogService {
     }
 
     @Transactional(readOnly = true)
-    public Stream<MessageLog> getPendingMessagesBetweenDates(LocalDateTime from, @NotNull LocalDateTime to) {
-        if (from == null) {
-            return messageLogRepository.findByStatusAndReceivedBefore(Status.PENDING, to);
-        }
-        return messageLogRepository.findByStatusAndReceivedBetween(Status.PENDING, from, to);
+    public List<Message> getPendingMessagesBetweenDates(LocalDateTime from, @NotNull LocalDateTime to) {
+        var messageLogStream = from == null
+                ? messageLogRepository.findByStatusAndReceivedBefore(Status.PENDING, to)
+                : messageLogRepository.findByStatusAndReceivedBetween(Status.PENDING, from, to);
+
+        return messageLogStream.map(Message::new).toList();
     }
 
 }

--- a/src/main/java/uk/gov/digital/ho/hocs/domain/service/ProcessingService.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/domain/service/ProcessingService.java
@@ -2,7 +2,6 @@ package uk.gov.digital.ho.hocs.domain.service;
 
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 import uk.gov.digital.ho.hocs.application.LogEvent;
 import uk.gov.digital.ho.hocs.domain.exceptions.ApplicationExceptions;
 import uk.gov.digital.ho.hocs.domain.model.Message;
@@ -24,7 +23,6 @@ public class ProcessingService {
         this.messageHandler = messageHandler;
     }
 
-    @Transactional
     public void retrieveAndProcessMessages(int maxMessages, LocalDateTime from, @NotNull LocalDateTime to) {
         checkMessageCount(maxMessages, from, to);
         processMessages(from, to);
@@ -32,17 +30,17 @@ public class ProcessingService {
 
     private void checkMessageCount(int maxMessages, LocalDateTime from, @NotNull LocalDateTime to) {
         var messageCount = messageLogService.getCountOfPendingMessagesBetweenDates(from, to);
+
         if (messageCount > maxMessages) {
             throw new ApplicationExceptions.TooManyMessagesException(
-                    String.format("Too many messages to process. Maximum allowed: %s. Current: %s", maxMessages, messageCount),
+                    String.format("Too many messages to process. Maximum allowed: %s. Current: %s.", maxMessages, messageCount),
                     LogEvent.TOO_MANY_MESSAGES);
         }
     }
 
     private void processMessages(LocalDateTime from, @NotNull LocalDateTime to) {
         var failedMessageCount = 0;
-        var messages = messageLogService.getPendingMessagesBetweenDates(from, to)
-                .map(Message::new).toList();
+        var messages = messageLogService.getPendingMessagesBetweenDates(from, to);
 
         for (Message message : messages) {
             try {

--- a/src/main/java/uk/gov/digital/ho/hocs/domain/service/ProcessingService.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/domain/service/ProcessingService.java
@@ -24,11 +24,15 @@ public class ProcessingService {
     }
 
     public void retrieveAndProcessMessages(int maxMessages, LocalDateTime from, @NotNull LocalDateTime to) {
-        checkMessageCount(maxMessages, from, to);
+        if (checkMessageCount(maxMessages, from, to) == 0) {
+            log.info("No messages to process.");
+            return;
+        }
+
         processMessages(from, to);
     }
 
-    private void checkMessageCount(int maxMessages, LocalDateTime from, @NotNull LocalDateTime to) {
+    private long checkMessageCount(int maxMessages, LocalDateTime from, @NotNull LocalDateTime to) {
         var messageCount = messageLogService.getCountOfPendingMessagesBetweenDates(from, to);
 
         if (messageCount > maxMessages) {
@@ -36,6 +40,8 @@ public class ProcessingService {
                     String.format("Too many messages to process. Maximum allowed: %s. Current: %s.", maxMessages, messageCount),
                     LogEvent.TOO_MANY_MESSAGES);
         }
+
+        return messageCount;
     }
 
     private void processMessages(LocalDateTime from, @NotNull LocalDateTime to) {
@@ -56,5 +62,7 @@ public class ProcessingService {
                     String.format("Failed to process message. %s messages failed to process.", failedMessageCount),
                     LogEvent.MESSAGE_PROCESSING_FAILURE);
         }
+
+        log.info("Processed {} messages.", messages.size() - failedMessageCount);
     }
 }

--- a/src/main/java/uk/gov/digital/ho/hocs/entrypoint/ProcessingController.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/entrypoint/ProcessingController.java
@@ -20,11 +20,11 @@ public class ProcessingController {
 
     @PostMapping("/process")
     public ResponseEntity<Void> processMessages(@RequestBody ProcessingRequest processingRequest) {
-        log.info("Processing {} messages from {} to {}", processingRequest.getMaxMessages(), processingRequest.getFrom(), processingRequest.getTo());
+        log.info("Processing {} messages from {} to {}.", processingRequest.getMaxMessages(), processingRequest.getFrom(), processingRequest.getTo());
         processingService.retrieveAndProcessMessages(processingRequest.getMaxMessages(),
                 processingRequest.getFrom(),
                 processingRequest.getTo());
-        log.info("Finished processing messages");
+        log.info("Finished processing messages.");
         return ResponseEntity.ok().build();
     }
 

--- a/src/test/java/uk/gov/digital/ho/hocs/domain/services/ProcessingServiceTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/domain/services/ProcessingServiceTest.java
@@ -8,13 +8,11 @@ import org.mockito.junit.MockitoJUnitRunner;
 import uk.gov.digital.ho.hocs.domain.exceptions.ApplicationExceptions;
 import uk.gov.digital.ho.hocs.domain.model.Message;
 import uk.gov.digital.ho.hocs.domain.queue.common.MessageHandler;
-import uk.gov.digital.ho.hocs.domain.repositories.entities.MessageLog;
-import uk.gov.digital.ho.hocs.domain.repositories.entities.Status;
 import uk.gov.digital.ho.hocs.domain.service.MessageLogService;
 import uk.gov.digital.ho.hocs.domain.service.ProcessingService;
 
 import java.time.LocalDateTime;
-import java.util.stream.Stream;
+import java.util.List;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.refEq;
@@ -41,8 +39,8 @@ public class ProcessingServiceTest {
     @Test
     public void whenMessageProcessSuccessfullyNoException() throws Exception {
         when(messageLogService.getCountOfPendingMessagesBetweenDates(any(), any())).thenReturn(1L);
-        when(messageLogService.getPendingMessagesBetweenDates(any(), any())).thenReturn(
-                Stream.of(new MessageLog("TEST-MESSAGE-ID", null, "TEST-MESSAGE", Status.PENDING, null)));
+        when(messageLogService.getPendingMessagesBetweenDates(any(), any()))
+                .thenReturn(List.of(new Message("TEST-MESSAGE-ID", "TEST-MESSAGE", null)));
 
         processingService.retrieveAndProcessMessages(10, LocalDateTime.now(), LocalDateTime.now());
 
@@ -59,8 +57,8 @@ public class ProcessingServiceTest {
     @Test(expected = ApplicationExceptions.FailedMessageProcessingException.class)
     public void whenMessageProcessingFailsThenThrowException() throws Exception {
         when(messageLogService.getCountOfPendingMessagesBetweenDates(any(), any())).thenReturn(1L);
-        when(messageLogService.getPendingMessagesBetweenDates(any(), any())).thenReturn(
-                Stream.of(new MessageLog("TEST-MESSAGE-ID", null, "TEST-MESSAGE", Status.PENDING, null)));
+        when(messageLogService.getPendingMessagesBetweenDates(any(), any()))
+                .thenReturn(List.of(new Message("TEST-MESSAGE-ID", "TEST-MESSAGE", null)));
 
         doThrow(new RuntimeException("TEST")).when(messageHandler).handleMessage(any());
 


### PR DESCRIPTION
The count and get of the MessageLogRepository where incorrectly returning messages that completed was before or between inputted dates. This should be retrieved.