### PR TITLE
HOCS-5649: support searches for migrated cases

### DIFF
--- a/src/main/java/uk/gov/digital/ho/hocs/client/migration/casework/dto/CreateMigrationCaseRequest.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/client/migration/casework/dto/CreateMigrationCaseRequest.java
@@ -31,4 +31,7 @@ public class CreateMigrationCaseRequest {
 
     @JsonProperty("stageType")
     private String stageType;
+
+    @JsonProperty("migratedReference")
+    private String migratedReference;
 }

--- a/src/main/java/uk/gov/digital/ho/hocs/domain/queue/migration/MigrationData.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/domain/queue/migration/MigrationData.java
@@ -22,8 +22,8 @@ public class MigrationData extends CaseData {
     private static final String ADDITIONAL_CORRESPONDENTS = "$.additionalCorrespondents";
     private static final String CASE_ATTACHMENTS = "$.caseAttachments";
     public static final String CLOSED_STATUS = "closed";
-
     public static final String CREATION_DATE = "$.creationDate";
+    public static final String MIGRATED_REFERENCE = "$.sourceCaseId";
 
     public MigrationData(String jsonBody) {
         super(jsonBody);
@@ -63,6 +63,10 @@ public class MigrationData extends CaseData {
 
     public Optional<String> getAdditionalCorrespondents() {
         return optionalString(ctx, ADDITIONAL_CORRESPONDENTS);
+    }
+
+    public String getMigratedReference() {
+        return ctx.read(MIGRATED_REFERENCE);
     }
 
     public Optional<String> optionalString(ReadContext ctx, String path) {

--- a/src/main/java/uk/gov/digital/ho/hocs/domain/queue/migration/MigrationService.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/domain/queue/migration/MigrationService.java
@@ -174,7 +174,8 @@ public class MigrationService {
             initialData,
             migrationData.getDateCompleted() != null
                 ? StageTypeMapping.getStageType(migrationData.getComplaintType())
-                : null
+                : null,
+            migrationData.getMigratedReference()
         );
     }
 

--- a/src/test/java/uk/gov/digital/ho/hocs/client/migration/casework/MigrationCaseworkClientTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/client/migration/casework/MigrationCaseworkClientTest.java
@@ -49,7 +49,8 @@ public class MigrationCaseworkClientTest {
                 date,
                 date,
                 data,
-                "COMP_MIGRATION_END");
+                "COMP_MIGRATION_END",
+                "test");
 
         CreateMigrationCaseResponse expectedResponse = new CreateMigrationCaseResponse(responseUUID, stageUUID, caseRef, data);
         ResponseEntity<CreateMigrationCaseResponse> responseEntity = new ResponseEntity<>(expectedResponse, HttpStatus.OK);

--- a/src/test/java/uk/gov/digital/ho/hocs/domain/queue/migration/MigrationServiceTest.java
+++ b/src/test/java/uk/gov/digital/ho/hocs/domain/queue/migration/MigrationServiceTest.java
@@ -102,7 +102,8 @@ public class MigrationServiceTest {
                 migrationData.getDateReceived(),
                 migrationData.getDateCompleted(),
                 initialData,
-                StageTypeMapping.getStageType("COMP"));
+                StageTypeMapping.getStageType("COMP"),
+                migrationData.getMigratedReference());
 
         caseworkCaseResponse = new CreateMigrationCaseResponse(
                 UUID.randomUUID(),


### PR DESCRIPTION
Changes to allow migratedReference to be propagated through to casework