### PR TITLE
Expose prometheus actuator endpoint with custom metric for webform processing failures

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,6 +56,7 @@ dependencies {
     implementation 'org.apache.commons:commons-text:1.10.0'
     implementation 'org.springframework.cloud:spring-cloud-aws-messaging:2.2.6.RELEASE'
     implementation group: 'org.jsoup', name: 'jsoup', version: '1.16.1'
+    runtimeOnly 'io.micrometer:micrometer-registry-prometheus'
 
     compileOnly "org.projectlombok:lombok:${lombokVersion}"
     annotationProcessor "org.projectlombok:lombok:${lombokVersion}"

--- a/src/main/java/uk/gov/digital/ho/hocs/domain/repositories/MessageLogRepository.java
+++ b/src/main/java/uk/gov/digital/ho/hocs/domain/repositories/MessageLogRepository.java
@@ -1,5 +1,6 @@
 package uk.gov.digital.ho.hocs.domain.repositories;
 
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
@@ -8,6 +9,7 @@ import uk.gov.digital.ho.hocs.domain.repositories.entities.MessageLog;
 import uk.gov.digital.ho.hocs.domain.repositories.entities.Status;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.UUID;
 import java.util.stream.Stream;
 
@@ -44,5 +46,8 @@ public interface MessageLogRepository extends CrudRepository<MessageLog, String>
     Stream<MessageLog> findByStatusAndReceivedBetween(Status status, LocalDateTime from, LocalDateTime to);
 
     Stream<MessageLog> findByStatusAndReceivedBefore(Status status, LocalDateTime to);
+
+    @Cacheable(value="messageLogcountByStatusIn")
+    long countByStatusIn(List<Status> status);
 
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -21,6 +21,10 @@ spring:
   jpa:
     database: postgresql
     open-in-view: false
+  cache:
+    type: caffeine
+    caffeine:
+      spec: maximumSize=500,expireAfterWrite=30m
 
 aws:
   sqs:
@@ -59,8 +63,18 @@ case:
 management:
   endpoints:
     enabled-by-default: false
+    web:
+      exposure:
+        include: health,prometheus
   endpoint:
     health:
       enabled: true
       probes:
         enabled: true
+    prometheus:
+      enabled: true
+  metrics:
+    export:
+      prometheus:
+        enabled: true
+


### PR DESCRIPTION
This adds a new actuator endpoint to expose prometheus metrics as well as adding a new metric to expose the number of failed messages. The value is cached for a period of 30 minutes to protect the database from the large number of calls made by prometheus 